### PR TITLE
fix: delayed commit new work for qbft

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -466,6 +466,10 @@ func (beacon *Beacon) SetThreads(threads int) {
 	}
 }
 
+func (beacon *Beacon) TimeForNextWork() uint64 {
+	return 0 // beacon does not require block period
+}
+
 // IsTTDReached checks if the TotalTerminalDifficulty has been surpassed on the `parentHash` block.
 // It depends on the parentHash already being stored in the database.
 // If the parentHash is not stored in the database a UnknownAncestor error is returned.

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -712,6 +712,10 @@ func (c *Clique) Close() error {
 	return nil
 }
 
+func (c *Clique) TimeForNextWork() uint64 {
+	return 0 // clique does not require block period
+}
+
 // CallEngineSpecific implements consensus.Engine
 func (c *Clique) CallEngineSpecific(method string, args ...interface{}) interface{} {
 	return nil

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -125,6 +125,9 @@ type Engine interface {
 	// Close terminates any background threads maintained by the consensus engine.
 	Close() error
 
+	// TimeForNextWork returns time to wait for next work(commit block)
+	TimeForNextWork() uint64
+
 	// CallEngineSpecific is special engine API as a kind of syntactic sugar.
 	// This function handles a wide variety of tasks specific to the consensus engine.
 	// Of course, conventional engines like ethash and clique won't do anything with this function.

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -561,6 +561,10 @@ func (ethash *Ethash) SealHash(header *types.Header) (hash common.Hash) {
 	return hash
 }
 
+func (ethash *Ethash) TimeForNextWork() uint64 {
+	return 0 // ethash does not require block period
+}
+
 // CallEngineSpecific implements consensus.Engine
 func (ethash *Ethash) CallEngineSpecific(method string, args ...interface{}) interface{} {
 	return nil

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -161,6 +161,13 @@ func (sb *Backend) VerifySeal(chain consensus.ChainHeaderReader, header *types.H
 	return sb.Engine().VerifySeal(chain, header, snap.ValSet)
 }
 
+func (sb *Backend) TimeToNextBlock() uint64 {
+	latestBlock := sb.currentBlock()
+	next := new(big.Int).Set(latestBlock.Number())
+	next = next.Add(next, big.NewInt(1))
+	return latestBlock.Time() + sb.Engine().PeriodToNextBlock(next)
+}
+
 // Prepare initializes the consensus fields of a block header according to the
 // rules of a particular engine. The changes are executed inline.
 func (sb *Backend) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -160,7 +160,8 @@ func (sb *Backend) VerifySeal(chain consensus.ChainHeaderReader, header *types.H
 	return sb.Engine().VerifySeal(chain, header, snap.ValSet)
 }
 
-func (sb *Backend) TimeToNextBlock() uint64 {
+// TimeForNextWork returns the time to wait for next work namely next block time
+func (sb *Backend) TimeForNextWork() uint64 {
 	if sb.currentBlock == nil {
 		return 0 // if it has no current block function then it returns zero time
 	}

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -22,10 +22,6 @@ package backend
 
 import (
 	"errors"
-	"math/big"
-	"math/rand"
-	"time"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/qbft"
@@ -38,6 +34,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"math/big"
+	"math/rand"
 )
 
 const (
@@ -249,20 +247,7 @@ func (sb *Backend) Seal(chain consensus.ChainHeaderReader, block *types.Block, r
 		return err
 	}
 
-	delay := time.Until(time.Unix(int64(block.Header().Time), 0))
-	if sb.simApplier != nil {
-		delay = time.Duration(0)
-	}
-
 	go func() {
-		// wait for the timestamp of header, use this to adjust the block period
-		select {
-		case <-time.After(delay):
-		case <-stop:
-			results <- nil
-			return
-		}
-
 		// get the proposed block hash and clear it if the seal() is completed.
 		sb.sealMu.Lock()
 		sb.proposedBlockHash = block.Hash()

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -22,6 +22,9 @@ package backend
 
 import (
 	"errors"
+	"math/big"
+	"math/rand"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/qbft"
@@ -34,8 +37,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-	"math/big"
-	"math/rand"
 )
 
 const (

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -162,7 +162,13 @@ func (sb *Backend) VerifySeal(chain consensus.ChainHeaderReader, header *types.H
 }
 
 func (sb *Backend) TimeToNextBlock() uint64 {
+	if sb.currentBlock == nil {
+		return 0 // if it has no current block function then it returns zero time
+	}
 	latestBlock := sb.currentBlock()
+	if latestBlock == nil {
+		return 0
+	}
 	next := new(big.Int).Set(latestBlock.Number())
 	next = next.Add(next, big.NewInt(1))
 	return latestBlock.Time() + sb.Engine().PeriodToNextBlock(next)

--- a/consensus/qbft/engine/engine.go
+++ b/consensus/qbft/engine/engine.go
@@ -447,6 +447,10 @@ func (e *Engine) VerifySeal(chain consensus.ChainHeaderReader, header *types.Hea
 	return e.verifySigner(chain, header, nil, validators)
 }
 
+func (e *Engine) PeriodToNextBlock(blockNumber *big.Int) uint64 {
+	return e.cfg.GetConfig(blockNumber).BlockPeriod
+}
+
 func (e *Engine) Prepare(chain consensus.ChainHeaderReader, header *types.Header, validators qbft.ValidatorSet) error {
 	header.Coinbase = common.Address{}
 	header.Nonce = qbftcommon.EmptyBlockNonce

--- a/consensus/wemix/consensus.go
+++ b/consensus/wemix/consensus.go
@@ -192,6 +192,13 @@ func (we *WemixConsensus) Close() error {
 	return we.wbft.Close()
 }
 
+func (we *WemixConsensus) TimeForNextWork() uint64 {
+	if we.wbftStarted {
+		return we.wbft.TimeForNextWork()
+	}
+	return we.wpoa.TimeForNextWork()
+}
+
 // CallEngineSpecific implements consensus.Engine
 func (we *WemixConsensus) CallEngineSpecific(method string, args ...interface{}) interface{} {
 	if we.wbftStarted {

--- a/consensus/wpoa/consensus.go
+++ b/consensus/wpoa/consensus.go
@@ -398,6 +398,11 @@ func (wpoa *WemixPoA) Close() error {
 	return nil
 }
 
+func (wpoa *WemixPoA) TimeForNextWork() uint64 {
+	// In case of WemixPoA, this should not be called
+	return 0
+}
+
 // CallEngineSpecific implements consensus.Engine
 func (wpoa *WemixPoA) CallEngineSpecific(method string, args ...interface{}) interface{} {
 	return nil

--- a/consensus/wpoa/fake.go
+++ b/consensus/wpoa/fake.go
@@ -97,6 +97,10 @@ func (wfpoa *WemixFakePoA) Close() error {
 	return wfpoa.wpoa.Close()
 }
 
+func (wfpoa *WemixFakePoA) TimeForNextWork() uint64 {
+	return 0
+}
+
 func (wfpoa *WemixFakePoA) CallEngineSpecific(method string, args ...interface{}) interface{} {
 	return nil
 }

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -148,7 +148,7 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 // CalcGasLimit computes the gas limit of the next block after parent. It aims
 // to keep the baseline gas close to the provided target, and increase it towards
 // the target if the baseline gas is lower.
-func CalcGasLimit(parentGasLimit, desiredLimit uint64) uint64 {
+func CalcGasLimitWemix(parentGasLimit, desiredLimit uint64) uint64 {
 	// WEMIX GasLimit policy
 	if desiredLimit == 0 { // governance is not initialized yet
 		return parentGasLimit
@@ -156,7 +156,7 @@ func CalcGasLimit(parentGasLimit, desiredLimit uint64) uint64 {
 	return desiredLimit
 }
 
-func CalcGasLimitOrigin(parentGasLimit, desiredLimit uint64) uint64 {
+func CalcGasLimit(parentGasLimit, desiredLimit uint64) uint64 {
 	delta := parentGasLimit/params.GasLimitBoundDivisor - 1
 	limit := parentGasLimit
 	if desiredLimit < params.MinGasLimit {

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -245,8 +245,8 @@ func TestCalcGasLimit(t *testing.T) {
 		max       uint64
 		min       uint64
 	}{
-		{20000000, 40000000, 20000000},
-		{40000000, 80000000, 40000000},
+		{20000000, 20019530, 19980470},
+		{40000000, 40039061, 39960939},
 	} {
 		// Increase
 		if have, want := CalcGasLimit(tc.pGasLimit, 2*tc.pGasLimit), tc.max; have != want {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -482,8 +482,12 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		if w.config.SimulatedEnabled {
 			delayTimer.Reset(0)
 		} else {
-			// worker needs to wait until the next block time to commit new work in case of qbft engine.
-			// if an another `tryCommit` call happens before delayTimer tick occurs, prior timer is discarded.
+			// There is some engine in which worker needs to wait until the next block time to commit new work(ex: qbft).
+			// In the previous QBFT engine, worker should wait for the block period when sealing.
+			// However, to create a finalized block(including extra seals) during the prepare phase, it is necessary
+			// to wait for the block period when processing new work. The reason for waiting during the prepare phase is
+			// to gather more extra seals.
+			// If another `tryCommit` call happens before delayTimer tick occurs, prior timer is discarded.
 			delayTimer.Reset(time.Until(time.Unix(int64(w.engine.TimeForNextWork()), 0)))
 		}
 		delayedInterruptType = s

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -449,15 +449,28 @@ func recalcRecommit(minRecommit, prev time.Duration, target float64, inc bool) t
 func (w *worker) newWorkLoop(recommit time.Duration) {
 	defer w.wg.Done()
 	var (
-		interrupt   *atomic.Int32
-		minRecommit = recommit // minimal resubmit interval specified by user.
-		timestamp   int64      // timestamp for each round of sealing.
+		interrupt            *atomic.Int32
+		minRecommit          = recommit // minimal resubmit interval specified by user.
+		timestamp            int64      // timestamp for each round of sealing.
+		delayedInterruptType int32
 	)
 
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 	<-timer.C // discard the initial tick
 
+	delayTimer := time.NewTimer(0)
+	defer delayTimer.Stop()
+	<-delayTimer.C // discard the initial tick
+
+	tryCommit := func(s int32) {
+		if qbftEngine, ok := w.engine.(*qbftBackend.Backend); ok {
+			delayTimer.Reset(time.Until(time.Unix(int64(qbftEngine.TimeToNextBlock()), 0)))
+		} else {
+
+		}
+
+	}
 	// commit aborts in-flight transaction execution with given signal and resubmits a new one.
 	commit := func(s int32) {
 		if interrupt != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -481,6 +481,9 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 	tryCommit := func(s int32) {
 		timeToWait := w.engine.TimeForNextWork()
 		if timeToWait == 0 || w.config.SimulatedEnabled {
+			// if there is prior timer, discard it
+			delayTimer.Reset(0)
+			<-delayTimer.C
 			commit(s)
 		} else {
 			// worker needs to wait until the next block time to commit new work in case of qbft engine.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -453,10 +453,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		minRecommit          = recommit // minimal resubmit interval specified by user.
 		timestamp            int64      // timestamp for each round of sealing.
 		delayedInterruptType int32
-		qbftEngine           *qbftBackend.Backend
 	)
-
-	qbftEngine, _ = w.engine.(*qbftBackend.Backend)
 
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -482,12 +479,13 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 	}
 
 	tryCommit := func(s int32) {
-		if qbftEngine == nil || w.config.SimulatedEnabled {
-			commit(s) // other than qbft engine; just call `commit()`
+		timeToWait := w.engine.TimeForNextWork()
+		if timeToWait == 0 || w.config.SimulatedEnabled {
+			commit(s)
 		} else {
 			// worker needs to wait until the next block time to commit new work in case of qbft engine.
 			// if an another `tryCommit` call happens before delayTimer tick occurs, prior timer is discarded.
-			delayTimer.Reset(time.Until(time.Unix(int64(qbftEngine.TimeToNextBlock()), 0)))
+			delayTimer.Reset(time.Until(time.Unix(int64(timeToWait), 0)))
 			delayedInterruptType = s
 		}
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -479,18 +479,14 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 	}
 
 	tryCommit := func(s int32) {
-		timeToWait := w.engine.TimeForNextWork()
-		if timeToWait == 0 || w.config.SimulatedEnabled {
-			// if there is prior timer, discard it
+		if w.config.SimulatedEnabled {
 			delayTimer.Reset(0)
-			<-delayTimer.C
-			commit(s)
 		} else {
 			// worker needs to wait until the next block time to commit new work in case of qbft engine.
 			// if an another `tryCommit` call happens before delayTimer tick occurs, prior timer is discarded.
-			delayTimer.Reset(time.Until(time.Unix(int64(timeToWait), 0)))
-			delayedInterruptType = s
+			delayTimer.Reset(time.Until(time.Unix(int64(w.engine.TimeForNextWork()), 0)))
 		}
+		delayedInterruptType = s
 	}
 
 	// clearPending cleans the stale pending tasks.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -453,7 +453,10 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		minRecommit          = recommit // minimal resubmit interval specified by user.
 		timestamp            int64      // timestamp for each round of sealing.
 		delayedInterruptType int32
+		qbftEngine           *qbftBackend.Backend
 	)
+
+	qbftEngine, _ = w.engine.(*qbftBackend.Backend)
 
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -463,14 +466,6 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 	defer delayTimer.Stop()
 	<-delayTimer.C // discard the initial tick
 
-	tryCommit := func(s int32) {
-		if qbftEngine, ok := w.engine.(*qbftBackend.Backend); ok {
-			delayTimer.Reset(time.Until(time.Unix(int64(qbftEngine.TimeToNextBlock()), 0)))
-		} else {
-
-		}
-
-	}
 	// commit aborts in-flight transaction execution with given signal and resubmits a new one.
 	commit := func(s int32) {
 		if interrupt != nil {
@@ -485,6 +480,18 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		timer.Reset(recommit)
 		w.newTxs.Store(0)
 	}
+
+	tryCommit := func(s int32) {
+		if qbftEngine == nil || w.config.SimulatedEnabled {
+			commit(s) // other than qbft engine; just call `commit()`
+		} else {
+			// worker needs to wait until the next block time to commit new work in case of qbft engine.
+			// if an another `tryCommit` call happens before delayTimer tick occurs, prior timer is discarded.
+			delayTimer.Reset(time.Until(time.Unix(int64(qbftEngine.TimeToNextBlock()), 0)))
+			delayedInterruptType = s
+		}
+	}
+
 	// clearPending cleans the stale pending tasks.
 	clearPending := func(number uint64) {
 		w.pendingMu.Lock()
@@ -501,7 +508,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		case <-w.startCh:
 			clearPending(w.chain.CurrentBlock().Number.Uint64())
 			timestamp = time.Now().Unix()
-			commit(commitInterruptNewHead)
+			tryCommit(commitInterruptNewHead)
 
 		case head := <-w.chainHeadCh:
 			// ## Quorum QBFT START
@@ -518,7 +525,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 
 			clearPending(head.Block.NumberU64())
 			timestamp = time.Now().Unix()
-			commit(commitInterruptNewHead)
+			tryCommit(commitInterruptNewHead)
 
 		case <-timer.C:
 			// If sealing is running resubmit a new work cycle periodically to pull in
@@ -529,8 +536,11 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 					timer.Reset(recommit)
 					continue
 				}
-				commit(commitInterruptResubmit)
+				tryCommit(commitInterruptResubmit)
 			}
+
+		case <-delayTimer.C:
+			commit(delayedInterruptType)
 
 		case interval := <-w.resubmitIntervalCh:
 			// Adjust resubmit interval explicitly by user.


### PR DESCRIPTION
- as is: Worker commits a new work just after new head has committed. So the qbft engine waits for a block period in `Seal()`.
- to be: Worker waits a block period before committing a new work so as it could `Prepare` a block including extra seals as many as possible
- other engine and simulated engine is not effected.
- etc: revoke wemix logic from `CalcGasLimit`