### PR TITLE
fix: ancient block error during syncing

### DIFF
--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -89,7 +89,11 @@ func (sb *Backend) verifyHeader(chain consensus.ChainHeaderReader, header *types
 	} else if header.Number.Uint64() < 2 {
 		return sb.Engine().VerifyHeader(chain, header, parents, snap.ValSet, snap.ValSet, true)
 	} else if len(parents) < 2 {
-		if prevSnap, err = sb.snapshot(chain, header.Number.Uint64()-2, chain.GetHeaderByNumber(header.Number.Uint64()-2).Hash(), nil); err != nil {
+		parent := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
+		if parent == nil {
+			return consensus.ErrUnknownAncestor
+		}
+		if prevSnap, err = sb.snapshot(chain, parent.Number.Uint64()-1, parent.ParentHash, nil); err != nil {
 			return err
 		}
 	} else {

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -89,9 +89,14 @@ func (sb *Backend) verifyHeader(chain consensus.ChainHeaderReader, header *types
 	} else if header.Number.Uint64() < 2 {
 		return sb.Engine().VerifyHeader(chain, header, parents, snap.ValSet, snap.ValSet, true)
 	} else if len(parents) < 2 {
-		parent := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
-		if parent == nil {
-			return consensus.ErrUnknownAncestor
+		var parent *types.Header
+		if len(parents) == 1 {
+			parent = parents[0]
+		} else {
+			parent = chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
+			if parent == nil {
+				return consensus.ErrUnknownAncestor
+			}
 		}
 		if prevSnap, err = sb.snapshot(chain, parent.Number.Uint64()-1, parent.ParentHash, nil); err != nil {
 			return err

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -101,7 +101,7 @@ func (sb *Backend) verifyHeader(chain consensus.ChainHeaderReader, header *types
 		if h.Number.Uint64() != header.Number.Uint64()-2 {
 			return errors.New("unexpected parents block")
 		}
-		if prevSnap, err = sb.snapshot(chain, h.Number.Uint64(), h.Hash(), nil); err != nil {
+		if prevSnap, err = sb.snapshot(chain, h.Number.Uint64(), h.Hash(), parents[:len(parents)-1]); err != nil {
 			return err
 		}
 	}

--- a/consensus/wemix/consensus.go
+++ b/consensus/wemix/consensus.go
@@ -3,6 +3,7 @@ package wemix
 import (
 	"crypto/ecdsa"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -25,7 +26,7 @@ import (
 type WemixConsensus struct {
 	wpoa        consensus.Engine
 	wbft        *qbftBackend.Backend
-	wbftStarted bool
+	wbftStarted atomic.Bool
 	stopCh      chan struct{}
 }
 
@@ -33,11 +34,12 @@ func NewWemixEngine(backend wemixgov.GovBackend, config *qbft.Config, privateKey
 	wpoa := wpoa.NewWemixPoAEngine(backend)
 	wbft := qbftBackend.New(config, privateKey, db)
 
-	return &WemixConsensus{
-		wpoa:        wpoa,
-		wbft:        wbft,
-		wbftStarted: false,
+	result := &WemixConsensus{
+		wpoa: wpoa,
+		wbft: wbft,
 	}
+	result.wbftStarted.Store(false)
+	return result
 }
 
 func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.ChainHeaderReader, currentBlock func() *types.Block, subscribeChainHead func(ch chan<- core.ChainHeadEvent) event.Subscription) {
@@ -53,7 +55,7 @@ func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.Chai
 			if err != nil {
 				log.Error("cannot start WEMIX BFT engine", "err", err)
 			}
-			we.wbftStarted = true
+			we.wbftStarted.Store(true)
 			log.Info("WEMIX BFT engine started because the current block is after MontBlanc hard fork")
 		} else {
 		loop:
@@ -66,7 +68,7 @@ func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.Chai
 						if err != nil {
 							log.Error("cannot start WEMIX BFT engine", "err", err)
 						}
-						we.wbftStarted = true
+						we.wbftStarted.Store(true)
 						log.Info("WEMIX BFT engine started because the current block is just at the MontBlanc hard fork")
 						break loop
 					}
@@ -83,7 +85,10 @@ func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.Chai
 }
 
 func (we *WemixConsensus) Stop() {
-	we.wbftStarted = false
+	if we.wbftStarted.Load() {
+		we.wbftStarted.Store(false)
+		we.wbft.Stop()
+	}
 	close(we.stopCh)
 }
 
@@ -197,7 +202,7 @@ func (we *WemixConsensus) Close() error {
 }
 
 func (we *WemixConsensus) TimeForNextWork() uint64 {
-	if we.wbftStarted {
+	if we.wbftStarted.Load() {
 		return we.wbft.TimeForNextWork()
 	}
 	return we.wpoa.TimeForNextWork()
@@ -205,21 +210,21 @@ func (we *WemixConsensus) TimeForNextWork() uint64 {
 
 // CallEngineSpecific implements consensus.Engine
 func (we *WemixConsensus) CallEngineSpecific(method string, args ...interface{}) interface{} {
-	if we.wbftStarted {
+	if we.wbftStarted.Load() {
 		return we.wbft.CallEngineSpecific(method, args)
 	}
 	return nil
 }
 
 func (we *WemixConsensus) NewChainHead() error {
-	if we.wbftStarted {
+	if we.wbftStarted.Load() {
 		return we.wbft.NewChainHead()
 	}
 	return nil
 }
 
 func (we *WemixConsensus) HandleMsg(address common.Address, data p2p.Msg) (bool, error) {
-	if we.wbftStarted {
+	if we.wbftStarted.Load() {
 		return we.wbft.HandleMsg(address, data)
 	}
 	return false, nil

--- a/consensus/wemix/consensus.go
+++ b/consensus/wemix/consensus.go
@@ -37,11 +37,12 @@ func NewWemixEngine(backend wemixgov.GovBackend, config *qbft.Config, privateKey
 		wpoa:        wpoa,
 		wbft:        wbft,
 		wbftStarted: false,
-		stopCh:      make(chan struct{}),
 	}
 }
 
 func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.ChainHeaderReader, currentBlock func() *types.Block, subscribeChainHead func(ch chan<- core.ChainHeadEvent) event.Subscription) {
+	we.stopCh = make(chan struct{})
+
 	chainHeadCh := make(chan core.ChainHeadEvent)
 	chainHeadSub := subscribeChainHead(chainHeadCh)
 
@@ -53,6 +54,7 @@ func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.Chai
 				log.Error("cannot start WEMIX BFT engine", "err", err)
 			}
 			we.wbftStarted = true
+			log.Info("WEMIX BFT engine started because the current block is after MontBlanc hard fork")
 		} else {
 		loop:
 			for {
@@ -65,6 +67,7 @@ func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.Chai
 							log.Error("cannot start WEMIX BFT engine", "err", err)
 						}
 						we.wbftStarted = true
+						log.Info("WEMIX BFT engine started because the current block is just at the MontBlanc hard fork")
 						break loop
 					}
 				case err := <-chainHeadSub.Err():
@@ -80,6 +83,7 @@ func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.Chai
 }
 
 func (we *WemixConsensus) Stop() {
+	we.wbftStarted = false
 	close(we.stopCh)
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1905,7 +1905,7 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator) (i
 	// ones. Any other errors means that the block is invalid, and should not be written
 	// to disk.
 	err := consensus.ErrPrunedAncestor
-	for ; block != nil && errors.Is(err, consensus.ErrPrunedAncestor); block, err = it.next() {
+	for ; block != nil && (errors.Is(err, consensus.ErrPrunedAncestor) || errors.Is(err, consensus.ErrUnknownAncestor)); block, err = it.next() {
 		// Check the canonical state root for that number
 		if number := block.NumberU64(); current.Number.Uint64() >= number {
 			canonical := bc.GetBlockByNumber(number)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1905,7 +1905,7 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator) (i
 	// ones. Any other errors means that the block is invalid, and should not be written
 	// to disk.
 	err := consensus.ErrPrunedAncestor
-	for ; block != nil && (errors.Is(err, consensus.ErrPrunedAncestor) || errors.Is(err, consensus.ErrUnknownAncestor)); block, err = it.next() {
+	for ; block != nil && errors.Is(err, consensus.ErrPrunedAncestor); block, err = it.next() {
 		// Check the canonical state root for that number
 		if number := block.NumberU64(); current.Number.Uint64() >= number {
 			canonical := bc.GetBlockByNumber(number)


### PR DESCRIPTION
Close #50 
- use `GetHeader` instead of `GetHeaderByNumber` in verifying block logic
  - `GetHeaderByNumber` can find a block hash only in the canonical chain
  - `GetHeader` can find the header not only the canonical chain but also in side chain db
  - block verification logic can be called during block syncing so it must handle blocks these are far from the canonical
- `blocks` of `VerifyHeaders` can be a batch of blocks these are far from canonical of local so it must use `parents` hint if it is given
- `engine.Stop` should be called once
- fix duplication of `engine.Start` call