### PR TITLE
fix: gas tip for montblanc hard fork

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -34,10 +34,9 @@ import (
 func VerifyEIP1559Header(config *params.ChainConfig, parent, header *types.Header) error {
 	// Verify that the gas limit remains within allowed bounds
 	parentGasLimit := parent.GasLimit
-	// WEMIX GasLimit policy
-	// if !config.IsLondon(parent.Number) {
-	// 	parentGasLimit = parent.GasLimit * config.ElasticityMultiplier()
-	// }
+	if !config.IsLondon(parent.Number) {
+		parentGasLimit = parent.GasLimit * config.ElasticityMultiplier()
+	}
 	if err := misc.VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
 		return err
 	}

--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -67,11 +67,11 @@ func TestBlockGasLimits(t *testing.T) {
 		ok        bool
 	}{
 		// Transitions from non-london to london
-		{10000000, 4, 10000000, true},  // No change
-		{10000000, 4, 10009764, true},  // Upper limit
-		{10000000, 4, 10009765, false}, // Upper +1
-		{10000000, 4, 9990236, true},   // Lower limit
-		{10000000, 4, 9990235, false},  // Lower limit -1
+		{10000000, 4, 20000000, true},  // No change
+		{10000000, 4, 20019530, true},  // Upper limit
+		{10000000, 4, 20019531, false}, // Upper +1
+		{10000000, 4, 19980470, true},  // Lower limit
+		{10000000, 4, 19980469, false}, // Lower limit -1
 		// London to London
 		{20000000, 5, 20000000, true},
 		{20000000, 5, 20019530, true},  // Upper limit

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -148,14 +148,6 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 // CalcGasLimit computes the gas limit of the next block after parent. It aims
 // to keep the baseline gas close to the provided target, and increase it towards
 // the target if the baseline gas is lower.
-func CalcGasLimitWemix(parentGasLimit, desiredLimit uint64) uint64 {
-	// WEMIX GasLimit policy
-	if desiredLimit == 0 { // governance is not initialized yet
-		return parentGasLimit
-	}
-	return desiredLimit
-}
-
 func CalcGasLimit(parentGasLimit, desiredLimit uint64) uint64 {
 	delta := parentGasLimit/params.GasLimitBoundDivisor - 1
 	limit := parentGasLimit

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -232,7 +232,7 @@ func (b *BlockGen) AddUncle(h *types.Header) {
 	if b.cm.config.IsLondon(h.Number) {
 		h.BaseFee = eip1559.CalcBaseFee(b.cm.config, parent)
 		if !b.cm.config.IsLondon(parent.Number) {
-			parentGasLimit := parent.GasLimit
+			parentGasLimit := parent.GasLimit * b.cm.config.ElasticityMultiplier()
 			h.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
 		}
 	}
@@ -446,7 +446,7 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 	if cm.config.IsLondon(header.Number) {
 		header.BaseFee = eip1559.CalcBaseFee(cm.config, parent.Header())
 		if !cm.config.IsLondon(parent.Number()) {
-			parentGasLimit := parent.GasLimit()
+			parentGasLimit := parent.GasLimit() * cm.config.ElasticityMultiplier()
 			header.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
 		}
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -363,7 +363,7 @@ func (b *EthAPIBackend) SyncProgress() ethereum.SyncProgress {
 }
 
 func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	return b.gpo.SuggestWemixTipCap(ctx)
+	return b.gpo.SuggestTipCap(ctx)
 }
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -142,10 +142,6 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 	}
 }
 
-func (oracle *Oracle) SuggestWemixTipCap(ctx context.Context) (*big.Int, error) {
-	return wpoa.SuggestGasPrice(), nil
-}
-
 // SuggestTipCap returns a tip cap so that newly created transaction can have a
 // very high chance to be included in the following blocks.
 //
@@ -154,6 +150,10 @@ func (oracle *Oracle) SuggestWemixTipCap(ctx context.Context) (*big.Int, error) 
 // behavior.
 func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	head, _ := oracle.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
+
+	if oracle.backend.ChainConfig().MontBlancBlock != nil && !oracle.backend.ChainConfig().IsMontBlanc(head.Number) {
+		return wpoa.SuggestGasPrice(), nil
+	}
 	headHash := head.Hash()
 
 	// If the latest gasprice is still available, return it.

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -119,7 +119,7 @@ func (b *testBackend) teardown() {
 
 // newTestBackend creates a test backend. OBS: don't forget to invoke tearDown
 // after use, otherwise the blockchain instance will mem-leak via goroutines.
-func newTestBackend(t *testing.T, montBlancBlock *big.Int, pending bool) *testBackend {
+func newTestBackend(t *testing.T, londonBlock *big.Int, pending bool) *testBackend {
 	var (
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr   = crypto.PubkeyToAddress(key.PublicKey)
@@ -130,13 +130,13 @@ func newTestBackend(t *testing.T, montBlancBlock *big.Int, pending bool) *testBa
 		}
 		signer = types.LatestSigner(gspec.Config)
 	)
-	config.LondonBlock = montBlancBlock
-	config.ArrowGlacierBlock = montBlancBlock
-	config.GrayGlacierBlock = montBlancBlock
-	config.PangyoBlock = montBlancBlock
-	config.ApplepieBlock = montBlancBlock
-	config.BriocheBlock = montBlancBlock
-	config.MontBlancBlock = montBlancBlock
+	config.LondonBlock = londonBlock
+	config.ArrowGlacierBlock = londonBlock
+	config.GrayGlacierBlock = londonBlock
+	config.PangyoBlock = nil
+	config.ApplepieBlock = nil
+	config.BriocheBlock = nil
+	config.MontBlancBlock = nil
 	engine := ethash.NewFaker()
 
 	// Generate testing blocks
@@ -144,7 +144,7 @@ func newTestBackend(t *testing.T, montBlancBlock *big.Int, pending bool) *testBa
 		b.SetCoinbase(common.Address{1})
 
 		var txdata types.TxData
-		if montBlancBlock != nil && b.Number().Cmp(montBlancBlock) >= 0 {
+		if londonBlock != nil && b.Number().Cmp(londonBlock) >= 0 {
 			txdata = &types.DynamicFeeTx{
 				ChainID:   gspec.Config.ChainID,
 				Nonce:     b.TxNonce(addr),

--- a/ethclient/test/ethclient_test.go
+++ b/ethclient/test/ethclient_test.go
@@ -520,7 +520,7 @@ func testStatusFunctions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gasPrice.Cmp(big.NewInt(100765625000)) != 0 {
+	if gasPrice.Cmp(big.NewInt(1000000000)) != 0 {
 		t.Fatalf("unexpected gas price: %v", gasPrice)
 	}
 
@@ -529,7 +529,7 @@ func testStatusFunctions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gasTipCap.Cmp(big.NewInt(100000000000)) != 0 {
+	if gasTipCap.Cmp(big.NewInt(234375000)) != 0 {
 		t.Fatalf("unexpected gas tip cap: %v", gasTipCap)
 	}
 


### PR DESCRIPTION
- fix `SuggestTipCap` in preparation for montblanc hard fork
- restore EIP1559 policy (this was modified by wemix porting)
  - this is used in mining a block
  - wemix engine does not use it before montblanc hard fork because it will not mine
  - wemix engine can verify wpoa blocks because wpoa engine uses modified EIP1559 policy