### PR TITLE
 fix: Support FeeDelegateDynamicFeeTxType

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -308,6 +308,11 @@ func (ks *KeyStore) SignTxWithPassphrase(a accounts.Account, passphrase string, 
 		return nil, err
 	}
 	defer zeroKey(key.PrivateKey)
+	// fee delegation
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		signer := types.NewFeeDelegateSigner(chainID)
+		return types.SignTx(tx, signer, key.PrivateKey)
+	}
 	// Depending on the presence of the chain ID, sign with or without replay protection.
 	signer := types.LatestSignerForChainID(chainID)
 	return types.SignTx(tx, signer, key.PrivateKey)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -610,7 +610,8 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 		Accept: 0 |
 			1<<types.LegacyTxType |
 			1<<types.AccessListTxType |
-			1<<types.DynamicFeeTxType,
+			1<<types.DynamicFeeTxType |
+			1<<types.FeeDelegateDynamicFeeTxType,
 		MaxSize: txMaxSize,
 		MinTip:  pool.gasTip.Load().ToBig(),
 	}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -278,7 +278,7 @@ func New(config Config, chain BlockChain) *LegacyPool {
 // pool, specifically, whether it is a Legacy, AccessList or Dynamic transaction.
 func (pool *LegacyPool) Filter(tx *types.Transaction) bool {
 	switch tx.Type() {
-	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType:
+	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType, types.FeeDelegateDynamicFeeTxType:
 		return true
 	default:
 		return false

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -41,7 +41,7 @@ var (
 type ValidationOptions struct {
 	Config *params.ChainConfig // Chain configuration to selectively validate based on current fork rules
 
-	Accept  uint8    // Bitmap of transaction types that should be accepted for the calling pool
+	Accept  uint32   // Bitmap of transaction types that should be accepted for the calling pool
 	MaxSize uint64   // Maximum size of a transaction that the caller can meaningfully handle
 	MinTip  *big.Int // Minimum gas tip needed to allow a transaction into the caller pool
 }

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -154,6 +154,8 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(itx.SenderTx.V)
 		enc.R = (*hexutil.Big)(itx.SenderTx.R)
 		enc.S = (*hexutil.Big)(itx.SenderTx.S)
+		yparity := itx.SenderTx.V.Uint64()
+		enc.YParity = (*hexutil.Uint64)(&yparity)
 
 		enc.FeePayer = itx.FeePayer
 		enc.FV = (*hexutil.Big)(itx.FV)
@@ -401,21 +403,28 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.V == nil {
 			return errors.New("missing required field 'v' in transaction")
 		}
-		itx.SenderTx.V = (*big.Int)(dec.V)
+
+		// signature R
 		if dec.R == nil {
 			return errors.New("missing required field 'r' in transaction")
 		}
 		itx.SenderTx.R = (*big.Int)(dec.R)
+		// signature S
 		if dec.S == nil {
 			return errors.New("missing required field 's' in transaction")
 		}
 		itx.SenderTx.S = (*big.Int)(dec.S)
-		withSignature := itx.SenderTx.V.Sign() != 0 || itx.SenderTx.R.Sign() != 0 || itx.SenderTx.S.Sign() != 0
-		if withSignature {
+		// signature V
+		itx.SenderTx.V, err = dec.yParityValue()
+		if err != nil {
+			return err
+		}
+		if itx.SenderTx.V.Sign() != 0 || itx.SenderTx.R.Sign() != 0 || itx.SenderTx.S.Sign() != 0 {
 			if err := sanityCheckSignature(itx.SenderTx.V, itx.SenderTx.R, itx.SenderTx.S, false); err != nil {
 				return err
 			}
 		}
+
 		if dec.FeePayer == nil {
 			return errors.New("missing required field 'feePayer' in transaction")
 		}
@@ -432,8 +441,8 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'fs' in transaction")
 		}
 		itx.FS = (*big.Int)(dec.FS)
-		withSignature = itx.FV.Sign() != 0 || itx.FR.Sign() != 0 || itx.FS.Sign() != 0
-		if withSignature {
+
+		if itx.FV.Sign() != 0 || itx.FR.Sign() != 0 || itx.FS.Sign() != 0 {
 			if err := sanityCheckSignature(itx.FV, itx.FR, itx.FS, false); err != nil {
 				return err
 			}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1467,8 +1467,10 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		// WEMIX fee delegation
 	case types.FeeDelegateDynamicFeeTxType:
 		al := tx.AccessList()
+		yparity := hexutil.Uint64(v.Sign())
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.YParity = &yparity
 		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
 		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
 		// if the transaction has been mined, compute the effective gas price


### PR DESCRIPTION
Note: This PR reverts #62 and creates it again.

Support FeeDelegateDynamicFeeTxType
- Added support for FeeDelegateDynamicFeeTxType in transaction validation.
- Changed ValidationOptions.Accept type to uint32 to enable handling of larger bitwise flags, such as 4194311.
- Implemented yParity property for FeeDelegateDynamicFeeTxType transactions in compliance with EIP-2930 and EIP-1559.