### PR TITLE
fix: consensus metrics

### DIFF
--- a/consensus/qbft/core/core.go
+++ b/consensus/qbft/core/core.go
@@ -200,6 +200,10 @@ func (c *Core) startNewRound(round *big.Int) {
 		oldLogger = c.logger.New("old.round", c.current.Round().Uint64(), "old.sequence", c.current.Sequence().Uint64(), "old.state", c.state.String(), "old.proposer", c.valSet.GetProposer())
 	}
 
+	if c.current != nil && round.Cmp(c.current.Round()) > 0 {
+		roundMeter.Mark(new(big.Int).Sub(round, c.current.Round()).Int64())
+	}
+
 	// Create next view
 	var newView *qbft.View
 	if roundChange {
@@ -221,10 +225,6 @@ func (c *Core) startNewRound(round *big.Int) {
 	// Calculate new proposer
 	c.valSet.CalcProposer(lastProposer, newView.Round.Uint64())
 	c.setState(StateAcceptRequest)
-
-	if c.current != nil && round.Cmp(c.current.Round()) > 0 {
-		roundMeter.Mark(new(big.Int).Sub(round, c.current.Round()).Int64())
-	}
 
 	// Update RoundChangeSet by deleting older round messages
 	if round.Uint64() == 0 {

--- a/consensus/qbft/core/core.go
+++ b/consensus/qbft/core/core.go
@@ -45,9 +45,10 @@ const (
 )
 
 var (
-	roundMeter     = metrics.NewRegisteredMeter("consensus/qbft/core/round", nil)
-	sequenceMeter  = metrics.NewRegisteredMeter("consensus/qbft/core/sequence", nil)
-	consensusTimer = metrics.NewRegisteredTimer("consensus/qbft/core/consensus", nil)
+	roundMeter        = metrics.NewRegisteredMeter("consensus/qbft/core/round", nil)
+	sequenceMeter     = metrics.NewRegisteredMeter("consensus/qbft/core/sequence", nil)
+	consensusTimer    = metrics.NewRegisteredTimer("consensus/qbft/core/consensus", nil)
+	timeoutRoundMeter = metrics.NewRegisteredMeter("consensus/qbft/core/timeout_round", nil)
 )
 
 // New creates a QBFT consensus core

--- a/consensus/qbft/core/handler.go
+++ b/consensus/qbft/core/handler.go
@@ -241,6 +241,8 @@ func (c *Core) handleTimeoutMsg() {
 	c.startNewRound(nextRound)
 	logger.Warn("QBFT: TIMER CHANGED ROUND", "pr", c.current.preparedRound)
 
+	timeoutRoundMeter.Mark(1)
+
 	// Send Round Change
 	c.broadcastRoundChange(nextRound)
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/holiman/uint256"
@@ -86,6 +87,10 @@ var (
 	errBlockInterruptedByNewHead  = errors.New("new head arrived while building block")
 	errBlockInterruptedByRecommit = errors.New("recommit interrupt while building block")
 	errBlockInterruptedByTimeout  = errors.New("timeout while building block")
+)
+
+var (
+	commitWorkTimer = metrics.NewRegisteredTimer("consensus/qbft/core/commitwork", nil)
 )
 
 // environment is the worker's current environment and holds all
@@ -1320,6 +1325,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 				log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
 					"txs", env.tcount, "gas", block.GasUsed(), "fees", feesInEther,
 					"elapsed", common.PrettyDuration(time.Since(start)))
+				commitWorkTimer.Update(time.Since(start))
 
 			case <-w.exitCh:
 				log.Info("Worker has exited")


### PR DESCRIPTION
# Changes

## Modification
- **`consensus_qbft_core_round` (Cumulative round count)**
  - **Issue:** Round change occurs but always displays `0`.
  - **Cause:** `roundMeter` is updated after `updateRoundState()`.
  - **Fix:** Changed the update position to accurately reflect round changes.

## Additions
- **`consensus_qbft_core_timeout_round`**
  - **Description:** Increases when a round change occurs due to a timeout.
  - **Purpose:** Tracks the frequency of round changes caused by timeouts.

- **`consensus_qbft_core_commitwork`**
  - **Description:** Measures the execution time of `CommitWork`.
  - **Purpose:** Monitors commitwork latency. 
