### PR TITLE
fix: start engine when miner starts

### DIFF
--- a/cmd/genesis_generator/genesis_generator.go
+++ b/cmd/genesis_generator/genesis_generator.go
@@ -75,36 +75,22 @@ func (g *genesisGenerator) makeGenesis() {
 	// Figure out which consensus engine to choose
 	fmt.Println()
 	fmt.Println("Which consensus engine to use? (default = Wbft)")
-	fmt.Println(" 1. Ethash (proof-of-work)")
-	fmt.Println(" 2. Beacon (proof-of-stake), merging/merged from Ethash (proof-of-work)")
-	fmt.Println(" 3. Clique (proof-of-authority)")
-	fmt.Println(" 4. Beacon (proof-of-stake), merging/merged from Clique (proof-of-authority)")
-	fmt.Println(" 5. WBFT (wemix-byzantine-fault-tolerance)")
-	fmt.Println(" 6. WEMIX (wemix-byzantine-fault-tolerance), merged from Wemix3.0 (proof-of-authority)")
+	fmt.Println(" 1. WBFT (wemix-byzantine-fault-tolerance)")
+	fmt.Println(" 2. WEMIX (wemix-byzantine-fault-tolerance), merged from Wemix3.0 (proof-of-authority)")
+	fmt.Println(" 3. Ethash (proof-of-work)")
+	fmt.Println(" 4. Beacon (proof-of-stake), merging/merged from Ethash (proof-of-work)")
+	fmt.Println(" 5. Clique (proof-of-authority)")
+	fmt.Println(" 6. Beacon (proof-of-stake), merging/merged from Clique (proof-of-authority)")
 
 	choice := read()
 	switch {
-	case choice == "1":
-		g.ethashConfig()
-
-	case choice == "2":
-		g.ethashConfig()
-		g.beaconChainConfig()
-
-	case choice == "3":
-		g.cliqueConfig()
-
-	case choice == "4":
-		g.cliqueConfig()
-		g.beaconChainConfig()
-
-	case choice == "5" || choice == "":
+	case choice == "1" || choice == "":
 		g.wbftChainConfig()
 		// allocate governanace contract code in genesis block
 		g.Genesis.Alloc[govwbft.GovConstAddress] = types.Account{Code: hexutil.MustDecode(govwbft.GovConstContract), Balance: common.Big0}
 		g.Genesis.Alloc[govwbft.GovStakingAddress] = types.Account{Code: hexutil.MustDecode(govwbft.GovStakingContract), Balance: common.Big0}
 
-	case choice == "6":
+	case choice == "2":
 		g.wbftChainConfig()
 		fmt.Println()
 		fmt.Println("Enter block number you want to enable Montblanc Fork (default 1)")
@@ -115,6 +101,20 @@ func (g *genesisGenerator) makeGenesis() {
 			g.Genesis.Alloc[govwbft.GovConstAddress] = types.Account{Code: hexutil.MustDecode(govwbft.GovConstContract), Balance: common.Big0}
 			g.Genesis.Alloc[govwbft.GovStakingAddress] = types.Account{Code: hexutil.MustDecode(govwbft.GovStakingContract), Balance: common.Big0}
 		}
+
+	case choice == "3":
+		g.ethashConfig()
+
+	case choice == "4":
+		g.ethashConfig()
+		g.beaconChainConfig()
+
+	case choice == "5":
+		g.cliqueConfig()
+
+	case choice == "6":
+		g.cliqueConfig()
+		g.beaconChainConfig()
 
 	default:
 		log.Crit("Invalid consensus engine choice", "choice", choice)
@@ -158,8 +158,6 @@ func (g *genesisGenerator) makeGenesis() {
 }
 
 func (g *genesisGenerator) wbftChainConfig() {
-	// TODO : need to be change after epoch task is merged.
-	// the qbft config needs to be set in field `Transition`
 	g.Genesis.Difficulty = types.QBFTDefaultDifficulty
 	fmt.Println()
 	fmt.Println("Which accounts are allowed to seal? (mandatory at least one)")
@@ -177,9 +175,9 @@ func (g *genesisGenerator) wbftChainConfig() {
 
 	g.Genesis.Config.QBFT = &params.QBFTConfig{
 		BlockReward:           (*math.HexOrDecimal256)(big.NewInt(params.Ether)),
-		EpochLength:           30000,
-		BlockPeriodSeconds:    2,
-		RequestTimeoutSeconds: 4,
+		EpochLength:           100,
+		BlockPeriodSeconds:    1,
+		RequestTimeoutSeconds: 2,
 		ProposerPolicy:        0,
 		Validators:            validators,
 	}

--- a/consensus/wemix/consensus.go
+++ b/consensus/wemix/consensus.go
@@ -3,8 +3,6 @@ package wemix
 import (
 	"crypto/ecdsa"
 	"math/big"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -18,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -26,11 +23,9 @@ import (
 )
 
 type WemixConsensus struct {
-	wpoa        consensus.Engine
-	wbft        *qbftBackend.Backend
-	wbftStarted atomic.Bool
-	once        sync.Once
-	stopCh      chan struct{}
+	wpoa   consensus.Engine
+	wbft   *qbftBackend.Backend
+	stopCh chan struct{}
 }
 
 func NewWemixEngine(backend wemixgov.GovBackend, config *qbft.Config, privateKey *ecdsa.PrivateKey, db ethdb.Database) consensus.Engine {
@@ -41,60 +36,17 @@ func NewWemixEngine(backend wemixgov.GovBackend, config *qbft.Config, privateKey
 		wpoa: wpoa,
 		wbft: wbft,
 	}
-	result.wbftStarted.Store(false)
 	return result
 }
 
 func (we *WemixConsensus) Start(config *params.ChainConfig, chain consensus.ChainHeaderReader, currentBlock func() *types.Block, subscribeChainHead func(ch chan<- core.ChainHeadEvent) event.Subscription, notifyNewRound func(waitTime time.Duration, round *big.Int)) {
 	we.stopCh = make(chan struct{})
-
-	chainHeadCh := make(chan core.ChainHeadEvent)
-	chainHeadSub := subscribeChainHead(chainHeadCh)
-
-	// WEMIX engine is waiting for MontBlanc hard fork then triggers qbft engine and quits its loop
-	go func() {
-		if config.IsMontBlanc(new(big.Int).Add(currentBlock().Number(), common.Big1)) {
-			err := we.wbft.Start(chain, currentBlock, rawdb.HasBadBlock, notifyNewRound)
-			if err != nil {
-				log.Error("cannot start WEMIX BFT engine", "err", err)
-			}
-			we.wbftStarted.Store(true)
-			log.Info("WEMIX BFT engine started because the current block is after MontBlanc hard fork")
-		} else {
-		loop:
-			for {
-				select {
-				case head := <-chainHeadCh:
-					if config.IsMontBlanc(new(big.Int).Add(head.Block.Number(), common.Big1)) {
-						log.Info("MontBlanc hard fork is activated. Starting WEMIX BFT engine")
-						err := we.wbft.Start(chain, currentBlock, rawdb.HasBadBlock, notifyNewRound)
-						if err != nil {
-							log.Error("cannot start WEMIX BFT engine", "err", err)
-						}
-						we.wbftStarted.Store(true)
-						log.Info("WEMIX BFT engine started because the current block is just at the MontBlanc hard fork")
-						break loop
-					}
-				case err := <-chainHeadSub.Err():
-					log.Warn("wemix consensus engine loop exits abnormally", "err", err)
-					break loop
-				case <-we.stopCh:
-					break loop
-				}
-			}
-		}
-		chainHeadSub.Unsubscribe()
-	}()
+	we.wbft.Start(chain, currentBlock, rawdb.HasBadBlock, notifyNewRound)
 }
 
 func (we *WemixConsensus) Stop() {
-	if we.wbftStarted.Load() {
-		we.wbftStarted.Store(false)
-		we.wbft.Stop()
-	}
-	we.once.Do(func() { // prevent panic in closing which is already closed
-		close(we.stopCh)
-	})
+	we.wbft.Stop()
+	close(we.stopCh)
 }
 
 func (we *WemixConsensus) Author(header *types.Header) (common.Address, error) {
@@ -102,6 +54,7 @@ func (we *WemixConsensus) Author(header *types.Header) (common.Address, error) {
 }
 
 func (we *WemixConsensus) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header) error {
+	// The fact that this engine is used implies that the MontBlanc hard fork is configured. (MontBlanc is not nil)
 	if chain.Config().IsMontBlanc(header.Number) {
 		return we.wbft.VerifyHeader(chain, header)
 	}
@@ -208,24 +161,15 @@ func (we *WemixConsensus) Close() error {
 
 // CallEngineSpecific implements consensus.Engine
 func (we *WemixConsensus) CallEngineSpecific(method string, args ...interface{}) interface{} {
-	if we.wbftStarted.Load() {
-		return we.wbft.CallEngineSpecific(method, args)
-	}
-	return nil
+	return we.wbft.CallEngineSpecific(method, args)
 }
 
 func (we *WemixConsensus) NewChainHead() error {
-	if we.wbftStarted.Load() {
-		return we.wbft.NewChainHead()
-	}
-	return nil
+	return we.wbft.NewChainHead()
 }
 
 func (we *WemixConsensus) HandleMsg(address common.Address, data p2p.Msg) (bool, error) {
-	if we.wbftStarted.Load() {
-		return we.wbft.HandleMsg(address, data)
-	}
-	return false, nil
+	return we.wbft.HandleMsg(address, data)
 }
 
 func (we *WemixConsensus) SetBroadcaster(broadcaster consensus.Broadcaster) {

--- a/consensus/wpoa/consensus.go
+++ b/consensus/wpoa/consensus.go
@@ -363,12 +363,7 @@ func (wpoa *WemixPoA) VerifyGasLimit(parentGasLimit, headerGasLimit uint64) erro
 // Prepare implements consensus.Engine, initializing the difficulty field of a
 // header to conform to the ethash protocol. The changes are done inline.
 func (wpoa *WemixPoA) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {
-	parent := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
-	if parent == nil {
-		return consensus.ErrUnknownAncestor
-	}
-	header.Difficulty = big.NewInt(1)
-	return nil
+	return errors.New("wpoa `Prepare` is disabled")
 }
 
 // Finalize implements consensus.Engine, accumulating the block and uncle rewards.

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -397,7 +397,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td, ttd *big.Int, 
 
 	// Post a user notification of the sync (only once per session)
 	if d.notified.CompareAndSwap(false, true) {
-		log.Info("Block synchronisation started")
+		log.Info("Block synchronisation started", "mode", mode)
 		defer log.Info("Block synchronisation finished")
 	}
 	if mode == SnapSync {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1118,6 +1118,12 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		header.ExcessBlobGas = &excessBlobGas
 		header.ParentBeaconRoot = genParams.beaconRoot
 	}
+
+	if w.chainConfig.MontBlancBlock != nil && !w.chainConfig.IsMontBlanc(header.Number) {
+		// If we are not in the MontBlanc phase, we don't prepare a block
+		log.Info("Skipping block preparation before MontBlanc hard fork", "number", header.Number, "fork", w.chainConfig.MontBlancBlock)
+		return nil, errors.New("skipping block preparation before MontBlanc hard fork")
+	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for sealing", "err", err)


### PR DESCRIPTION
- start wbft engine when miner starts
- tested mont blanc hard fork on devnet (consensus transition: wpoa -> wbft)
- how to start a wbft miner on mainnet or testnet with mont blanc hard fork
  - 1) snap sync
    - start node with `--sync snap` and without `--miner`
    - wait for full sync
    - stop the node and start node with `--miner`
  - 2) full sync
    - start node with `--miner`

=================================================
Log message for testing devent
- last wpoa block: 22,871,819
- mont blanc hard fork block: 22,871,820

```
INFO [02-11|08:33:34.269] Skipping block preparation before MontBlanc hard fork number=22,871,819 fork=22,871,820
INFO [02-11|08:33:35.265] Imported new chain segment               number=22,871,819 hash=e06a7e..ae7751 blocks=1  txs=0 mgas=0.000 elapsed=17.595ms  mgasps=0.000 snapdiffs=996.15KiB triedirty=947.12KiB
INFO [02-11|08:33:35.265] QBFT: handle final committed             address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,819 state="Accept request"
INFO [02-11|08:33:35.265] QBFT: initialize new round               address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,819 target.round=0 lastProposal.number=22,871,819 lastProposal.hash=e06a7e..ae7751
INFO [02-11|08:33:35.265] QBFT: start new round                    address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 old.round=0 old.sequence=22,871,819 old.state="Accept request" old.proposer=<nil> next.round=0 next.seq=22,871,820 next.proposer=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 next.valSet=[0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697] next.size=1 next.IsProposer=true
WARN [02-11|08:33:35.274] Error while calculating rewards          err="invalid extra data format" // -> will be fixed with PR #60
INFO [02-11|08:33:35.276] QBFT: handle block proposal request      address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state="Accept request"
INFO [02-11|08:33:35.277] Commit new sealing work                  number=22,871,820 sealhash=5b2adc..26715c txs=1 gas=872,776 fees=0.0872776 elapsed=11.252ms
INFO [02-11|08:33:35.277] QBFT: broadcast PRE-PREPARE message      address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state="Accept request" msg.code=18 msg.source=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 msg.round=0 msg.sequence=22,871,820 block.number=22,871,820 block.hash=0x5b2adcf48c3c49d17f98e7856fb6b952e396234a84dbd7869da02b7a8326715c payload=0xf911ef...
INFO [02-11|08:33:35.278] QBFT: handle PRE-PREPARE message         address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697
INFO [02-11|08:33:35.278] QBFT: accepted PRE-PREPARE message       address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697
INFO [02-11|08:33:35.278] QBFT: changed state                      address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 old.state="Accept request" new.state=Preprepared
INFO [02-11|08:33:35.278] QBFT: broadcast PREPARE message          address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state=Preprepared msg.code=19 msg.source=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 msg.round=0 msg.sequence=22,871,820 payload=0xf8aff86a84015cff0c80a05b2adcf48c3c49d17f98e7856fb6b952e396234a84dbd7869da02b7a8326715cb8417c79037aa11e919721e294e406506b4b81199cbb426c7e5e6c9726b28bb09b5d310e6088a975c4d49942fd4777f014ba3b45af719b117b19c9fd0c90366bfa7400b8419fdf8e970ae711785d76bffde2a6b82f6af10f6f9fdb70efca58761ecb7ef9f45755260f176a8497f8de5d6a85c5b6e6ce73c94c0d1c663c119a10bbb0feb25701
INFO [02-11|08:33:35.279] QBFT: handle PREPARE message             address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state=Preprepared msg.code=19 msg.source=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 msg.round=0 msg.sequence=22,871,820 prepares.count=0 quorum=1
INFO [02-11|08:33:35.279] QBFT: received quorum of PREPARE messages address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state=Preprepared msg.code=19 msg.source=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 msg.round=0 msg.sequence=22,871,820 prepares.count=1 quorum=1
INFO [02-11|08:33:35.279] QBFT: changed state                      address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 old.state=Preprepared new.state=Prepared
INFO [02-11|08:33:35.279] QBFT: broadcast COMMIT message           address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state=Prepared msg.code=20 msg.source=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 msg.round=0 msg.sequence=22,871,820 payload=0xf8aff86a84015cff0c80a05b2adcf48c3c49d17f98e7856fb6b952e396234a84dbd7869da02b7a8326715cb841e8c96bd1e24d2fe250eb5905e760811ef08b1e6520203617af5261675599e22f0a070dc63f87025568922adf2a915881e309d92a712c3a3adecf5bcdf04e29ba01b84195a61d0f49bf00c3b24d41be343d2150668642a81df725cccc8cf345aaa6600959a68a85ef879757ae94d4d41f0d26b55c6c3169899db8e9018b4b2bd10a6ee700
INFO [02-11|08:33:35.279] QBFT: handle COMMIT message              address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state=Prepared msg.code=20 msg.source=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 msg.round=0 msg.sequence=22,871,820 commits.count=0 quorum=1
INFO [02-11|08:33:35.280] QBFT: received quorum of COMMIT messages address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state=Prepared msg.code=20 msg.source=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 msg.round=0 msg.sequence=22,871,820 commits.count=1 quorum=1
INFO [02-11|08:33:35.280] QBFT: changed state                      address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 old.state=Prepared new.state=Committed
INFO [02-11|08:33:35.280] BFT: block proposal committed            author=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 hash=5b2adc..26715c number=22,871,820
INFO [02-11|08:33:35.291] Successfully sealed new block            number=22,871,820 sealhash=5b2adc..26715c hash=5b2adc..26715c elapsed=15.155ms
INFO [02-11|08:33:35.291] QBFT: handle final committed             address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 state=Committed
INFO [02-11|08:33:35.292] QBFT: initialize new round               address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,820 target.round=0 lastProposal.number=22,871,820 lastProposal.hash=5b2adc..26715c
INFO [02-11|08:33:35.292] QBFT: changed state                      address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 current.round=0 current.sequence=22,871,821 old.state=Committed new.state="Accept request"
INFO [02-11|08:33:35.292] QBFT: start new round                    address=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 old.round=0 old.sequence=22,871,820 old.state=Committed old.proposer=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 next.round=0 next.seq=22,871,821 next.proposer=0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697 next.valSet=[0xaA5FAA65e9cC0F74a85b6fDfb5f6991f5C094697] next.size=1 next.IsProposer=true
INFO [02-11|08:33:35.295] Looking for peers                        peercount=0 tried=0 static=1
INFO [02-11|08:33:36.001] Commit new sealing work                  number=22,871,821 sealhash=fea3bd..c2690a txs=0 gas=0       fees=0         elapsed="674.708µs"
```
