### PR TITLE
fix: wbft core concurrency bug

### DIFF
--- a/consensus/qbft/backend/backend.go
+++ b/consensus/qbft/backend/backend.go
@@ -306,7 +306,9 @@ func (sb *Backend) Validators(proposal qbft.Proposal) qbft.ValidatorSet {
 	return valSet
 }
 
-func (sb *Backend) ProposerFromValSet() common.Address {
+func (sb *Backend) getProposerForTest() common.Address {
+	// used only for testing
+	// if you want actual using, you should lock coreMu for it
 	return sb.core.GetProposer()
 }
 

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -227,6 +227,8 @@ func (sb *Backend) Seal(chain consensus.ChainHeaderReader, block *types.Block, r
 }
 
 func (sb *Backend) processExtraSeals() (map[common.Hash][]byte, map[common.Hash][]byte) {
+	sb.coreMu.Lock()
+	defer sb.coreMu.Unlock()
 	if sb.core == nil {
 		return nil, nil
 	} else {

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -228,7 +228,7 @@ func (sb *Backend) Seal(chain consensus.ChainHeaderReader, block *types.Block, r
 
 func (sb *Backend) processExtraSeals() (map[common.Hash][]byte, map[common.Hash][]byte) {
 	sb.coreMu.RLock()
-	defer sb.coreMu.Unlock()
+	defer sb.coreMu.RUnlock()
 	if sb.core == nil {
 		return nil, nil
 	} else {

--- a/consensus/qbft/backend/engine.go
+++ b/consensus/qbft/backend/engine.go
@@ -227,7 +227,7 @@ func (sb *Backend) Seal(chain consensus.ChainHeaderReader, block *types.Block, r
 }
 
 func (sb *Backend) processExtraSeals() (map[common.Hash][]byte, map[common.Hash][]byte) {
-	sb.coreMu.Lock()
+	sb.coreMu.RLock()
 	defer sb.coreMu.Unlock()
 	if sb.core == nil {
 		return nil, nil

--- a/consensus/qbft/backend/engine_test.go
+++ b/consensus/qbft/backend/engine_test.go
@@ -855,7 +855,7 @@ func makeBlockThroughConsensus(chain *core.BlockChain, engine *Backend, nodes []
 			switch consensusState {
 			case qbftcore.StateAcceptRequest:
 				for _, node := range nodes {
-					if engine.ProposerFromValSet() == node.address {
+					if engine.getProposerForTest() == node.address {
 						header := proposedBlock.Header()
 						header.Coinbase = node.address
 						statedb, err := chain.State()


### PR DESCRIPTION
WBFT engine panic
- `Prepare()` and `Stop()` called concurrently
- coreMu.lock required in using `Backend.core`

```
INFO [02-11|18:11:57.933] BFT: deactivate
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xee1671]

goroutine 56 [running]:
github.com/ethereum/go-ethereum/consensus/qbft/core.(*Core).PriorRound(...)
	github.com/ethereum/go-ethereum/consensus/qbft/core/core.go:125
github.com/ethereum/go-ethereum/consensus/qbft/backend.(*Backend).processExtraSeals(0xc0003d4500)
	github.com/ethereum/go-ethereum/consensus/qbft/backend/engine.go:233 +0x31
github.com/ethereum/go-ethereum/consensus/qbft/backend.(*Backend).Prepare(0xc0003d4500, {0x2051ae8, 0xc000505c08}, 0xc00c6d0848)
	github.com/ethereum/go-ethereum/consensus/qbft/backend/engine.go:167 +0x10b
github.com/ethereum/go-ethereum/miner.(*worker).prepareWork(0xc00014c248, 0xc00c6e1ca8)
	github.com/ethereum/go-ethereum/miner/worker.go:1122 +0x78a
github.com/ethereum/go-ethereum/miner.(*worker).commitWork(0xc00014c248, 0xc0134d3210, 0x67ab145d)
	github.com/ethereum/go-ethereum/miner/worker.go:1249 +0x12e
github.com/ethereum/go-ethereum/miner.(*worker).mainLoop(0xc00014c248)
	github.com/ethereum/go-ethereum/miner/worker.go:657 +0x44a
created by github.com/ethereum/go-ethereum/miner.newWorker in goroutine 1
	github.com/ethereum/go-ethereum/miner/worker.go:310 +0x9bb
```