### PR TITLE
fix: prevent double round change

### DIFF
--- a/consensus/qbft/core/core.go
+++ b/consensus/qbft/core/core.go
@@ -103,8 +103,9 @@ type Core struct {
 	currentMutex sync.Mutex
 	handlerWg    *sync.WaitGroup
 
-	roundChangeSet   *roundChangeSet
-	roundChangeTimer *time.Timer
+	roundChangeSet          *roundChangeSet
+	roundChangeTimer        *time.Timer
+	lastSentTimeoutCalceled *bool
 
 	QBFTPreparedPrepares []*qbftmessage.Prepare
 
@@ -292,6 +293,9 @@ func (c *Core) stopTimer() {
 	if c.roundChangeTimer != nil {
 		c.roundChangeTimer.Stop()
 	}
+	if c.lastSentTimeoutCalceled != nil {
+		*c.lastSentTimeoutCalceled = true
+	}
 }
 
 func (c *Core) newRoundChangeTimer() {
@@ -333,8 +337,10 @@ func (c *Core) newRoundChangeTimer() {
 	}
 
 	c.currentLogger(true, nil).Trace("QBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
+	c.lastSentTimeoutCalceled = new(bool)
+	*c.lastSentTimeoutCalceled = false
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
-		c.sendEvent(timeoutEvent{})
+		c.sendEvent(timeoutEvent{c.lastSentTimeoutCalceled})
 	})
 }
 

--- a/consensus/qbft/core/core.go
+++ b/consensus/qbft/core/core.go
@@ -105,7 +105,7 @@ type Core struct {
 
 	roundChangeSet          *roundChangeSet
 	roundChangeTimer        *time.Timer
-	lastSentTimeoutCalceled *bool
+	lastSentTimeoutCanceled *bool
 
 	QBFTPreparedPrepares []*qbftmessage.Prepare
 
@@ -293,8 +293,8 @@ func (c *Core) stopTimer() {
 	if c.roundChangeTimer != nil {
 		c.roundChangeTimer.Stop()
 	}
-	if c.lastSentTimeoutCalceled != nil {
-		*c.lastSentTimeoutCalceled = true
+	if c.lastSentTimeoutCanceled != nil {
+		*c.lastSentTimeoutCanceled = true
 	}
 }
 
@@ -337,10 +337,10 @@ func (c *Core) newRoundChangeTimer() {
 	}
 
 	c.currentLogger(true, nil).Trace("QBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
-	c.lastSentTimeoutCalceled = new(bool)
-	*c.lastSentTimeoutCalceled = false
+	c.lastSentTimeoutCanceled = new(bool)
+	*c.lastSentTimeoutCanceled = false
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
-		c.sendEvent(timeoutEvent{c.lastSentTimeoutCalceled})
+		c.sendEvent(timeoutEvent{c.lastSentTimeoutCanceled})
 	})
 }
 

--- a/consensus/qbft/core/events.go
+++ b/consensus/qbft/core/events.go
@@ -30,4 +30,6 @@ type backlogEvent struct {
 	msg qbftmessage.QBFTMessage
 }
 
-type timeoutEvent struct{}
+type timeoutEvent struct {
+	canceled *bool
+}

--- a/consensus/qbft/core/handler.go
+++ b/consensus/qbft/core/handler.go
@@ -145,12 +145,15 @@ func (c *Core) handleEvents() {
 				// if successfully processed, we gossip message to other validators
 				c.backend.Gossip(c.valSet, ev.msg.Code(), data)
 			}
-		case _, ok := <-c.timeoutSub.Chan():
+		case toEvent, ok := <-c.timeoutSub.Chan():
 			// we received a round change timeout
 			if !ok {
 				return
 			}
-			c.handleTimeoutMsg()
+			if !*toEvent.Data.(timeoutEvent).canceled {
+				// timeout event can be canceled if a new round is started before timeout
+				c.handleTimeoutMsg()
+			}
 		case event, ok := <-c.finalCommittedSub.Chan():
 			// our block proposal got committed
 			if !ok {

--- a/event/event.go
+++ b/event/event.go
@@ -36,8 +36,6 @@ type TypeMuxEvent struct {
 // called after mux is stopped will return ErrMuxClosed.
 //
 // The zero value is ready to use.
-//
-// Deprecated: use Feed
 type TypeMux struct {
 	mutex   sync.RWMutex
 	subm    map[reflect.Type][]*TypeMuxSubscription

--- a/event/event.go
+++ b/event/event.go
@@ -36,6 +36,8 @@ type TypeMuxEvent struct {
 // called after mux is stopped will return ErrMuxClosed.
 //
 // The zero value is ready to use.
+//
+// Deprecated: use Feed
 type TypeMux struct {
 	mutex   sync.RWMutex
 	subm    map[reflect.Type][]*TypeMuxSubscription


### PR DESCRIPTION
- round changing can occur twice
  - round change timeout and receiving 2/3+ timeout message can occur simultaneously
  - `startNewRound` is called by latter
  - and then timeout -> timeoutEvent sent
  - `startNewRound` ends and called again by timeoutEvent

- solution
  - during `startNewRound`, cancel prior sent timeoutEvent