### PR TITLE
fix: assembleblock failure of TestEth2NewBlock

### DIFF
--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -127,7 +127,15 @@ func TestEth2AssembleBlock(t *testing.T) {
 // number of transactions in it, or it has retried three times.
 func assembleWithTransactions(api *ConsensusAPI, parentHash common.Hash, params *engine.PayloadAttributes, want int) (execData *engine.ExecutableData, err error) {
 	for retries := 3; retries > 0; retries-- {
+		runnable, _ := api.eth.TxPool().Stats()
+		//Wait and retry if there aren't enough transactions
+		if runnable < want {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
 		execData, err = assembleBlock(api, parentHash, params)
+
 		if err != nil {
 			return nil, err
 		}

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -127,22 +127,19 @@ func TestEth2AssembleBlock(t *testing.T) {
 // number of transactions in it, or it has retried three times.
 func assembleWithTransactions(api *ConsensusAPI, parentHash common.Hash, params *engine.PayloadAttributes, want int) (execData *engine.ExecutableData, err error) {
 	for retries := 3; retries > 0; retries-- {
-		runnable, _ := api.eth.TxPool().Stats()
-		//Wait and retry if there aren't enough transactions
-		if runnable < want {
-			time.Sleep(500 * time.Millisecond)
-			continue
-		}
 
 		execData, err = assembleBlock(api, parentHash, params)
 
 		if err != nil {
 			return nil, err
 		}
+
 		if have, want := len(execData.Transactions), want; have != want {
 			err = fmt.Errorf("invalid number of transactions, have %d want %d", have, want)
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
+		
 		return execData, nil
 	}
 	return nil, err

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -127,7 +127,6 @@ func TestEth2AssembleBlock(t *testing.T) {
 // number of transactions in it, or it has retried three times.
 func assembleWithTransactions(api *ConsensusAPI, parentHash common.Hash, params *engine.PayloadAttributes, want int) (execData *engine.ExecutableData, err error) {
 	for retries := 3; retries > 0; retries-- {
-
 		execData, err = assembleBlock(api, parentHash, params)
 
 		if err != nil {
@@ -139,7 +138,7 @@ func assembleWithTransactions(api *ConsensusAPI, parentHash common.Hash, params 
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		
+
 		return execData, nil
 	}
 	return nil, err


### PR DESCRIPTION
### Changes
- Modified and hardened retries logic functionality
### Why we did it
- In rare cases, the test fails because the transaction is not included in the block.
### Review requests
- Please review the code 