### PR TITLE
feat: add GetWbftExtraInfo RPC API to retrieve QBFT extra data

### DIFF
--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -312,13 +312,13 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 	bNumber := big.NewInt(int64(number))
 
 	if qbft.GetFirstWbftBlockNumber(api.chain.Config()).Cmp(bNumber) > 0 {
-		return nil, errors.New("not a WBFT block")
+		return nil, qbftcommon.ErrIsNotWBFTBlock
 	}
 
 	header := api.chain.GetHeaderByNumber(uint64(number))
 
 	if header == nil {
-		return nil, errors.New("not a WBFT block")
+		return nil, fmt.Errorf("block %d not found", bNumber)
 	}
 
 	extra, err := types.ExtractQBFTExtra(header)

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -25,6 +25,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
+	"unicode/utf8"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	qbft "github.com/ethereum/go-ethereum/consensus/qbft"
@@ -32,8 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"math/big"
-	"unicode/utf8"
 )
 
 // API is a user facing RPC API to dump Istanbul state
@@ -242,7 +243,6 @@ func sealForJSON(seal *types.QBFTAggregatedSeal, valSet []common.Address) map[st
 		"sealers":   sealers,
 		"signature": hex.EncodeToString(seal.Signature),
 	}
-
 }
 
 func epochForJSON(epoch *types.EpochInfo) map[string]interface{} {
@@ -262,7 +262,6 @@ func epochForJSON(epoch *types.EpochInfo) map[string]interface{} {
 	// Validators
 	validators := make([]map[string]interface{}, 0, len(epoch.Validators))
 	for i, idx := range epoch.Validators {
-
 		validators = append(validators, map[string]interface{}{
 			"index": fmt.Sprintf("0x%x", idx),
 			"addr":  epoch.GetValidator(idx).Hex(),
@@ -274,13 +273,11 @@ func epochForJSON(epoch *types.EpochInfo) map[string]interface{} {
 		"stakers":    stakers,
 		"validators": validators,
 	}
-
 }
 
 // DecodeVanityData decodes a 32-byte vanityData field.
 // It detects if the input is UTF-8 or RLP encoded, and decodes accordingly.
 func DecodeVanityData(vanity []byte) string {
-
 	clean := bytes.TrimRight(vanity, "\x00")
 
 	if utf8.Valid(clean) {
@@ -341,5 +338,4 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 	}
 
 	return result, nil
-
 }

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -21,16 +21,18 @@
 package backend
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	qbftcommon "github.com/ethereum/go-ethereum/consensus/qbft/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	"math/big"
+	"unicode/utf8"
 )
 
 // API is a user facing RPC API to dump Istanbul state
@@ -277,6 +279,34 @@ func epochForJSON(epoch *types.EpochInfo, valSet []common.Address) map[string]in
 
 }
 
+// DecodeVanityData decodes a 32-byte vanityData field.
+// It detects if the input is UTF-8 or RLP encoded, and decodes accordingly.
+func DecodeVanityData(vanity []byte) string {
+
+	clean := bytes.TrimRight(vanity, "\x00")
+
+	if utf8.Valid(clean) {
+		return string(clean)
+	}
+
+	var val []interface{}
+
+	err := rlp.DecodeBytes(clean, &val)
+	versionBytes := val[0].([]uint8)
+	version := uint32(versionBytes[0])<<16 | uint32(versionBytes[1])<<8 | uint32(versionBytes[2])
+	if err == nil && version > 0 {
+		major := version >> 16
+		minor := (version >> 8) & 0xff
+		patch := version & 0xff
+		clientBytes := val[1].([]byte)
+		goVerBytes := val[2].([]byte)
+		goOSBytes := val[3].([]byte)
+		return fmt.Sprintf("[version: v%d.%d.%d, client: %s, go: %s, os: %s]", major, minor, patch, string(clientBytes), string(goVerBytes), string(goOSBytes))
+	}
+
+	return fmt.Sprintf("Unknown vanityData format, hex: 0x%s", hex.EncodeToString(clean))
+}
+
 func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}, error) {
 	bNumber := big.NewInt(int64(number))
 
@@ -298,8 +328,9 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 
 	validators, err := api.GetValidators(&number)
 
+	//"vanityData":        strings.TrimRight(string(extra.VanityData), "\x00"),
 	result := map[string]interface{}{
-		"vanityData":        "decoded string message",
+		"vanityData":        DecodeVanityData(extra.VanityData),
 		"prevRound":         fmt.Sprintf("0x%x", extra.PrevRound),
 		"prevPreparedSeal":  sealForJSON(extra.PrevPreparedSeal, validators),
 		"prevCommittedSeal": sealForJSON(extra.PrevCommittedSeal, validators),

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -325,6 +325,9 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 	}
 
 	validators, err := api.GetValidators(&number)
+	if err != nil {
+		return nil, err
+	}
 
 	result := map[string]interface{}{
 		"vanityData":        DecodeVanityData(extra.VanityData),

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -245,7 +245,7 @@ func sealForJSON(seal *types.QBFTAggregatedSeal, valSet []common.Address) map[st
 
 }
 
-func epochForJSON(epoch *types.EpochInfo, valSet []common.Address) map[string]interface{} {
+func epochForJSON(epoch *types.EpochInfo) map[string]interface{} {
 	if epoch == nil {
 		return nil
 	}
@@ -261,15 +261,12 @@ func epochForJSON(epoch *types.EpochInfo, valSet []common.Address) map[string]in
 
 	// Validators
 	validators := make([]map[string]interface{}, 0, len(epoch.Validators))
-	for _, idx := range epoch.Validators {
-		if int(idx) >= len(valSet) || int(idx) >= len(epoch.BLSPublicKeys) {
-			continue
-		}
+	for i, idx := range epoch.Validators {
 
 		validators = append(validators, map[string]interface{}{
 			"index": fmt.Sprintf("0x%x", idx),
-			"addr":  valSet[idx].Hex(),
-			"bls":   "0x" + hex.EncodeToString(epoch.BLSPublicKeys[idx]),
+			"addr":  epoch.GetValidator(idx).Hex(),
+			"bls":   "0x" + hex.EncodeToString(epoch.BLSPublicKeys[i]),
 		})
 	}
 
@@ -338,7 +335,7 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 		"round":             fmt.Sprintf("0x%x", extra.Round),
 		"preparedSeal":      sealForJSON(extra.PreparedSeal, validators),
 		"committedSeal":     sealForJSON(extra.CommittedSeal, validators),
-		"epochInfo":         epochForJSON(extra.EpochInfo, validators),
+		"epochInfo":         epochForJSON(extra.EpochInfo),
 	}
 
 	return result, nil

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -21,7 +21,10 @@
 package backend
 
 import (
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -216,4 +219,96 @@ func (api *API) IsValidator(blockNum *rpc.BlockNumber) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func sealForJSON(seal *types.QBFTAggregatedSeal, valSet []common.Address) map[string]interface{} {
+	if seal == nil {
+		return nil
+	}
+
+	sealerIndxs := seal.Sealers.GetSealers()
+	sealers := make([]string, 0, len(sealerIndxs))
+
+	for _, idx := range sealerIndxs {
+		if int(idx) < len(valSet) {
+			sealers = append(sealers, valSet[idx].Hex())
+		}
+	}
+
+	return map[string]interface{}{
+		"sealers":   sealers,
+		"signature": hex.EncodeToString(seal.Signature),
+	}
+
+}
+
+func epochForJSON(epoch *types.EpochInfo, valSet []common.Address) map[string]interface{} {
+	if epoch == nil {
+		return nil
+	}
+	// Stakers
+	stakers := make([]map[string]interface{}, 0, len(epoch.Stakers))
+
+	for _, s := range epoch.Stakers {
+		stakers = append(stakers, map[string]interface{}{
+			"addr":      s.Addr.Hex(),
+			"diligence": fmt.Sprintf("0x%x", s.Diligence),
+		})
+	}
+
+	// Validators
+	validators := make([]map[string]interface{}, 0, len(epoch.Validators))
+	for _, idx := range epoch.Validators {
+		if int(idx) >= len(valSet) || int(idx) >= len(epoch.BLSPublicKeys) {
+			continue
+		}
+
+		validators = append(validators, map[string]interface{}{
+			"index": fmt.Sprintf("0x%x", idx),
+			"addr":  valSet[idx].Hex(),
+			"bls":   "0x" + hex.EncodeToString(epoch.BLSPublicKeys[idx]),
+		})
+	}
+
+	return map[string]interface{}{
+		"stakers":    stakers,
+		"validators": validators,
+	}
+
+}
+
+func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}, error) {
+	bNumber := big.NewInt(int64(number))
+
+	if (api.chain.Config().MontBlancBlock == nil) || api.chain.Config().MontBlancBlock.Cmp(bNumber) > 0 {
+		return nil, errors.New("not a WBFT block")
+	}
+
+	header := api.chain.GetHeaderByNumber(uint64(number))
+
+	if header == nil {
+		return nil, errors.New("not a WBFT block")
+	}
+
+	extra, err := types.ExtractQBFTExtra(header)
+
+	if err != nil {
+		return nil, err
+	}
+
+	validators, err := api.GetValidators(&number)
+
+	result := map[string]interface{}{
+		"vanityData":        "decoded string message",
+		"prevRound":         fmt.Sprintf("0x%x", extra.PrevRound),
+		"prevPreparedSeal":  sealForJSON(extra.PrevPreparedSeal, validators),
+		"prevCommittedSeal": sealForJSON(extra.PrevCommittedSeal, validators),
+		"round":             fmt.Sprintf("0x%x", extra.Round),
+		"preparedSeal":      sealForJSON(extra.PreparedSeal, validators),
+		"committedSeal":     sealForJSON(extra.CommittedSeal, validators),
+		"epochInfo":         epochForJSON(extra.EpochInfo, validators),
+	}
+
+	return result, nil
+
 }

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -326,7 +326,6 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 
 	validators, err := api.GetValidators(&number)
 
-	//"vanityData":        strings.TrimRight(string(extra.VanityData), "\x00"),
 	result := map[string]interface{}{
 		"vanityData":        DecodeVanityData(extra.VanityData),
 		"prevRound":         fmt.Sprintf("0x%x", extra.PrevRound),

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	qbft "github.com/ethereum/go-ethereum/consensus/qbft"
 	qbftcommon "github.com/ethereum/go-ethereum/consensus/qbft/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -310,7 +311,7 @@ func DecodeVanityData(vanity []byte) string {
 func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}, error) {
 	bNumber := big.NewInt(int64(number))
 
-	if (api.chain.Config().MontBlancBlock == nil) || api.chain.Config().MontBlancBlock.Cmp(bNumber) > 0 {
+	if qbft.GetFirstWbftBlockNumber(api.chain.Config()).Cmp(bNumber) > 0 {
 		return nil, errors.New("not a WBFT block")
 	}
 

--- a/consensus/qbft/backend/api.go
+++ b/consensus/qbft/backend/api.go
@@ -241,7 +241,7 @@ func sealForJSON(seal *types.QBFTAggregatedSeal, valSet []common.Address) map[st
 
 	return map[string]interface{}{
 		"sealers":   sealers,
-		"signature": hex.EncodeToString(seal.Signature),
+		"signature": "0x" + hex.EncodeToString(seal.Signature),
 	}
 }
 
@@ -290,9 +290,7 @@ func DecodeVanityData(vanity []byte) string {
 	versionBytes := val[0].([]uint8)
 	version := uint32(versionBytes[0])<<16 | uint32(versionBytes[1])<<8 | uint32(versionBytes[2])
 	if err == nil && version > 0 {
-		major := version >> 16
-		minor := (version >> 8) & 0xff
-		patch := version & 0xff
+		major, minor, patch := versionBytes[0], versionBytes[1], versionBytes[2]
 		clientBytes := val[1].([]byte)
 		goVerBytes := val[2].([]byte)
 		goOSBytes := val[3].([]byte)

--- a/consensus/qbft/engine/engine_test.go
+++ b/consensus/qbft/engine/engine_test.go
@@ -75,7 +75,6 @@ func toTestAccount(prvKey string) account {
 	key, _ := crypto.ToECDSA(hexutil.MustDecode(prvKey))
 	blsKey, _ := bls.DeriveFromECDSA(key)
 	addr := crypto.PubkeyToAddress(key.PublicKey)
-
 	return account{key: key, blsKey: blsKey, addr: addr}
 }
 

--- a/consensus/qbft/engine/engine_test.go
+++ b/consensus/qbft/engine/engine_test.go
@@ -76,8 +76,6 @@ func toTestAccount(prvKey string) account {
 	blsKey, _ := bls.DeriveFromECDSA(key)
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
-	//fmt.Println("account addr: , bls : , key: ", addr, hexutil.Encode(blsKey.PublicKey().Marshal()), key)
-
 	return account{key: key, blsKey: blsKey, addr: addr}
 }
 

--- a/consensus/qbft/engine/engine_test.go
+++ b/consensus/qbft/engine/engine_test.go
@@ -76,6 +76,8 @@ func toTestAccount(prvKey string) account {
 	blsKey, _ := bls.DeriveFromECDSA(key)
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
+	//fmt.Println("account addr: , bls : , key: ", addr, hexutil.Encode(blsKey.PublicKey().Marshal()), key)
+
 	return account{key: key, blsKey: blsKey, addr: addr}
 }
 

--- a/ethclient/simulated/wbft_backend_test.go
+++ b/ethclient/simulated/wbft_backend_test.go
@@ -53,6 +53,13 @@ func TestNewWbftBackend(t *testing.T) {
 	if block.Hash() != hash {
 		t.Fatal("committed block hash is different")
 	}
+
+	var result map[string]interface{}
+	err = sim.client.Client.Client().CallContext(context.Background(), &result, "istanbul_getWbftExtraInfo", "0x1")
+
+	if err != nil {
+		t.Fatalf("istanbul_getWbftExtraInfo failed: %v", err)
+	}
 }
 
 func TestWbftAdjustTime(t *testing.T) {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -1020,6 +1020,13 @@ web3._extend({
             inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 
+		new web3._extend.Method({
+			name: 'getWbftExtraInfo',
+			call: 'istanbul_getWbftExtraInfo',
+			params: 1,
+            inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+
 	],
 	properties:
 	[

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -637,6 +637,7 @@ web3._extend({
 			call: 'eth_signRawFeeDelegateTransaction',
 			params: 2,
 		}),
+		
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
### Purpose
Add a new RPC API called `istanbul_getWbftExtraInfo` to extract meaningful information from the ExtraData field of WBFT blocks.  

### Changes.
- Added `GetWbftExtraInfo` function to `consensus/qbft/backend/api.go`.
- Register corresponding RPC methods in `web3ext.go`
- Write some simulated test code (see `TestNewWbftBackend`)

### Test.

- [x] normal response when calling `istanbul_getWbftExtraInfo`
- [x] check error return when passing non-WBFT block number (`block is not a wbft block`)
- [x] Normal handling of nil value, no epoch info, etc.
- [x] Normal response when testing RPC API using Ethereum clients and HTTP clients (e.g. curl, Postman)
