### PR TITLE
fix: diligence bug and doc

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [1.21]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -41,7 +41,7 @@ jobs:
         run: make lint
 
   unit_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -211,10 +211,10 @@ type WBFTExtra struct {
 
 ### Fee Policy
 While the fee policy is not strictly part of the WBFT protocol itself, this section explains the changes compared to the existing WEMIX 3.0 fee structure.
-The previous WEMIX 3.0 fee policy (https://docs.wemix.com/en/design/eip1559) followed EIP-1559 but included the following unique WEMIX-specific rules:
+The previous [WEMIX 3.0 fee policy](https://docs.wemix.com/en/design/eip1559) followed [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) but included the following unique WEMIX-specific rules:
 - Modified behavior of the eth_maxPriorityFeePerGas API: It returned a fixed value of 100 Gwei.
 - Custom baseFee calculation method: (Refer to the document linked above).
-- Mandatory fixed priorityFee for dynamic fee transactions: When using dynamic fees in transactions (tx), the priorityFee had to be explicitly set to 100 Gwei. Otherwise, the transaction would be immediately rejected by the mempool with an error.
+- Mandatory fixed priorityFee for dynamic fee transactions: When using dynamic fees in transactions, the priorityFee had to be explicitly set to >= 100 Gwei. Otherwise, the transaction would be immediately rejected by the mempool with an error.
 
 In contrast, WEMIX 3.5 and WBFT chains adhere strictly to the original EIP-1559 standard, which is designed to foster a competitive fee market among validators, suitable for a public chain environment.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The existing miner worker is designed to be fit to the ethash algorithm. When a 
 - The WBFT engine waits for the block period before notifying the worker(In the existing IBFT, the block period was waited for when sealing the block).
 - When new work starts, the worker begins the process of preparing the block.
 
-### Modified Sturctures
+### Modified Structures
 The existing QBFT Config was revised by removing unnecessary fields and adding required ones, resulting in the following structure.
 ```
 "qbft": {
@@ -208,6 +208,20 @@ type WBFTExtra struct {
 	Epoch                       EpochInfo
 }
 ```
+
+### Fee Policy
+While the fee policy is not strictly part of the WBFT protocol itself, this section explains the changes compared to the existing WEMIX 3.0 fee structure.
+The previous WEMIX 3.0 fee policy (https://docs.wemix.com/en/design/eip1559) followed EIP-1559 but included the following unique WEMIX-specific rules:
+- Modified behavior of the eth_maxPriorityFeePerGas API: It returned a fixed value of 100 Gwei.
+- Custom baseFee calculation method: (Refer to the document linked above).
+- Mandatory fixed priorityFee for dynamic fee transactions: When using dynamic fees in transactions (tx), the priorityFee had to be explicitly set to 100 Gwei. Otherwise, the transaction would be immediately rejected by the mempool with an error.
+
+In contrast, WEMIX 3.5 and WBFT chains adhere strictly to the original EIP-1559 standard, which is designed to foster a competitive fee market among validators, suitable for a public chain environment.
+
+Consequently:
+- The return value of the eth_maxPriorityFeePerGas API can now vary based on network conditions.
+- The baseFee calculation follows the standard EIP-1559 specification.
+- The original EIP-1559 behavior, where specifying a higher priorityFee prioritizes the transaction for inclusion in the block (mempool), has been restored.
 
 ### WEMIX 3.5
 
@@ -445,7 +459,7 @@ aware of and agree upon. This consists of a small JSON file (e.g. call it `genes
 ```json
 {
   "config": {
-    "chainId": <arbitrary positive integer>,
+    "chainId": 1234,
     "homesteadBlock": 0,
     "eip150Block": 0,
     "eip155Block": 0,

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ type WBFTExtra struct {
 }
 ```
 
-### Fee Policy
+### Gas Fee Policy
 While the fee policy is not strictly part of the WBFT protocol itself, this section explains the changes compared to the existing WEMIX 3.0 fee structure.
 The previous [WEMIX 3.0 fee policy](https://docs.wemix.com/en/design/eip1559) followed [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) but included the following unique WEMIX-specific rules:
 - Modified behavior of the eth_maxPriorityFeePerGas API: It returned a fixed value of 100 Gwei.

--- a/consensus/qbft/engine/engine.go
+++ b/consensus/qbft/engine/engine.go
@@ -688,6 +688,12 @@ func (e *Engine) buildEpochInfo(chain consensus.ChainHeaderReader, header *types
 				stakerMap[addr].wasValidator = true
 			}
 		}
+	} else if it.Number.Sign() != 0 {
+		// exeption case: if "it" is the montblanc block, all current stakers were validators in the montblanc block
+		// in other words, all current stakers can have the previous seals in the point of the first block
+		for _, st := range stakerMap {
+			st.wasValidator = true
+		}
 	}
 
 	// Accumulate proposer counts being selected within epoch.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1264,6 +1264,7 @@ func (w *worker) commitWork(interrupt *atomic.Int32, timestamp int64) {
 		coinbase:  coinbase,
 	})
 	if err != nil {
+		log.Error("Fail to prepare work", "err", err)
 		return
 	}
 	// Fill pending transactions from the txpool into the block.
@@ -1296,8 +1297,11 @@ func (w *worker) commitWork(interrupt *atomic.Int32, timestamp int64) {
 		return
 	}
 	// Submit the generated block for consensus sealing.
-	w.commit(work.copy(), w.fullTaskHook, true, start)
-
+	err = w.commit(work.copy(), w.fullTaskHook, true, start)
+	if err != nil {
+		log.Error("Fail to commit work", "err", err)
+		return
+	}
 	// Swap out the old work with the new one, terminating any leftover
 	// prefetcher processes in the mean time and starting a new one.
 	if w.current != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -87,6 +87,7 @@ var (
 	errBlockInterruptedByNewHead  = errors.New("new head arrived while building block")
 	errBlockInterruptedByRecommit = errors.New("recommit interrupt while building block")
 	errBlockInterruptedByTimeout  = errors.New("timeout while building block")
+	errSkipMiningBeforeMontBlanc  = errors.New("skipping block preparation before MontBlanc hard fork")
 )
 
 var (
@@ -1129,7 +1130,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if w.chainConfig.MontBlancBlock != nil && !w.chainConfig.IsMontBlanc(header.Number) {
 		// If we are not in the MontBlanc phase, we don't prepare a block
 		log.Info("Skipping block preparation before MontBlanc hard fork", "number", header.Number, "fork", w.chainConfig.MontBlancBlock)
-		return nil, errors.New("skipping block preparation before MontBlanc hard fork")
+		return nil, errSkipMiningBeforeMontBlanc
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {
@@ -1264,7 +1265,9 @@ func (w *worker) commitWork(interrupt *atomic.Int32, timestamp int64) {
 		coinbase:  coinbase,
 	})
 	if err != nil {
-		log.Error("Fail to prepare work", "err", err)
+		if !errors.Is(err, errSkipMiningBeforeMontBlanc) {
+			log.Error("Fail to prepare work", "err", err)
+		}
 		return
 	}
 	// Fill pending transactions from the txpool into the block.


### PR DESCRIPTION
Latest dev branch failed at montblanc hard fork test: failed to make the first epoch block after hard fork.

- in montblanc hard fork case: all validators can make seal for the montblanc block, so they may have all prev seals at the first block. we need exception rule for this. (in wbft chain, we have no prev seals at the first block)
- added fee policy to readme
