### PR TITLE
fix: adjust sync condition based on TD difference

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -116,6 +116,8 @@ var (
 		utils.DiscoveryPortFlag,
 		utils.MaxPeersFlag,
 		utils.MaxPendingPeersFlag,
+		utils.ForceSyncCycleFlag,
+		utils.TdSyncIntervalFlag,
 		utils.MiningEnabledFlag,
 		utils.MinerGasLimitFlag,
 		utils.MinerGasPriceFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -778,6 +778,18 @@ var (
 		Value:    30303,
 		Category: flags.NetworkingCategory,
 	}
+	ForceSyncCycleFlag = &cli.DurationFlag{
+		Name:     "forcesynccycle",
+		Usage:    "Interval between forced sync cycles with peers",
+		Value:    ethconfig.Defaults.ForceSyncCycle,
+		Category: flags.NetworkingCategory,
+	}
+	TdSyncIntervalFlag = &cli.DurationFlag{
+		Name:     "tdsyncinterval",
+		Usage:    "Interval at which total difficulty is checked for sync progress",
+		Value:    ethconfig.Defaults.TdSyncInterval,
+		Category: flags.NetworkingCategory,
+	}
 
 	// Console
 	JSpathFlag = &flags.DirectoryFlag{
@@ -1631,6 +1643,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(NetworkIdFlag.Name) {
 		cfg.NetworkId = ctx.Uint64(NetworkIdFlag.Name)
+	}
+	if ctx.IsSet(ForceSyncCycleFlag.Name) {
+		cfg.ForceSyncCycle = ctx.Duration(ForceSyncCycleFlag.Name)
+	}
+	if ctx.IsSet(TdSyncIntervalFlag.Name) {
+		cfg.TdSyncInterval = ctx.Duration(TdSyncIntervalFlag.Name)
 	}
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheDatabaseFlag.Name) {
 		cfg.DatabaseCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) / 100

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -779,14 +779,14 @@ var (
 		Category: flags.NetworkingCategory,
 	}
 	ForceSyncCycleFlag = &cli.DurationFlag{
-		Name:     "forcesynccycle",
-		Usage:    "Interval between forced sync cycles with peers",
+		Name:     "sync.forcecycle",
+		Usage:    "Time interval to force syncs, even if few peers are available",
 		Value:    ethconfig.Defaults.ForceSyncCycle,
 		Category: flags.NetworkingCategory,
 	}
 	TdSyncIntervalFlag = &cli.DurationFlag{
-		Name:     "tdsyncinterval",
-		Usage:    "Interval at which total difficulty is checked for sync progress",
+		Name:     "sync.tdinterval",
+		Usage:    "Time interval to verify TD changes and detect sync stalling",
 		Value:    ethconfig.Defaults.TdSyncInterval,
 		Category: flags.NetworkingCategory,
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -257,6 +257,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		Merger:         eth.merger,
 		Network:        networkID,
 		Sync:           config.SyncMode,
+		ForceSyncCycle: config.ForceSyncCycle,
+		TdSyncInterval: config.TdSyncInterval,
 		BloomCache:     uint64(cacheLimit),
 		EventMux:       eth.eventMux,
 		RequiredBlocks: config.RequiredBlocks,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -61,7 +61,9 @@ var Defaults = Config{
 	// ## Quorum QBFT START
 	//SyncMode: downloader.SnapSync,
 	// Quorum - make full sync the default sync mode in quorum (as opposed to upstream geth)
-	SyncMode: downloader.FullSync,
+	SyncMode:       downloader.FullSync,
+	ForceSyncCycle: 10 * time.Second, // Time interval to force syncs, even if few peers are available
+	TdSyncInterval: 10 * time.Second, // Time interval to verify TD changes and detect sync stalling
 	// ## Quorum QBFT END
 
 	NetworkId:          0, // enable auto configuration of networkID == chainID
@@ -94,8 +96,10 @@ type Config struct {
 
 	// Network ID separates blockchains on the peer-to-peer networking level. When left
 	// zero, the chain ID is used as network ID.
-	NetworkId uint64
-	SyncMode  downloader.SyncMode
+	NetworkId      uint64
+	SyncMode       downloader.SyncMode
+	ForceSyncCycle time.Duration
+	TdSyncInterval time.Duration
 
 	// This can be set to list of enrtree:// URLs which will be queried for
 	// for nodes to connect to.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -21,6 +21,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Genesis                 *core.Genesis `toml:",omitempty"`
 		NetworkId               uint64
 		SyncMode                downloader.SyncMode
+		ForceSyncCycle          time.Duration
+		TdSyncInterval          time.Duration
 		EthDiscoveryURLs        []string
 		SnapDiscoveryURLs       []string
 		NoPruning               bool
@@ -63,6 +65,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Genesis = c.Genesis
 	enc.NetworkId = c.NetworkId
 	enc.SyncMode = c.SyncMode
+	enc.ForceSyncCycle = c.ForceSyncCycle
+	enc.TdSyncInterval = c.TdSyncInterval
 	enc.EthDiscoveryURLs = c.EthDiscoveryURLs
 	enc.SnapDiscoveryURLs = c.SnapDiscoveryURLs
 	enc.NoPruning = c.NoPruning
@@ -109,6 +113,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		Genesis                 *core.Genesis `toml:",omitempty"`
 		NetworkId               *uint64
 		SyncMode                *downloader.SyncMode
+		ForceSyncCycle          *time.Duration
+		TdSyncInterval          *time.Duration
 		EthDiscoveryURLs        []string
 		SnapDiscoveryURLs       []string
 		NoPruning               *bool
@@ -159,6 +165,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.SyncMode != nil {
 		c.SyncMode = *dec.SyncMode
+	}
+	if dec.ForceSyncCycle != nil {
+		c.ForceSyncCycle = *dec.ForceSyncCycle
+	}
+	if dec.TdSyncInterval != nil {
+		c.TdSyncInterval = *dec.TdSyncInterval
 	}
 	if dec.EthDiscoveryURLs != nil {
 		c.EthDiscoveryURLs = dec.EthDiscoveryURLs

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -98,6 +98,8 @@ type handlerConfig struct {
 	Merger         *consensus.Merger      // The manager for eth1/2 transition
 	Network        uint64                 // Network identifier to advertise
 	Sync           downloader.SyncMode    // Whether to snap or full sync
+	ForceSyncCycle time.Duration          // Time interval to force syncs, even if few peers are available
+	TdSyncInterval time.Duration          // Time interval to verify TD changes and detect sync stalling
 	BloomCache     uint64                 // Megabytes to alloc for snap sync bloom
 	EventMux       *event.TypeMux         // Legacy event mux, deprecate for `feed`
 	RequiredBlocks map[uint64]common.Hash // Hard coded map of required block hashes for sync challenges
@@ -111,10 +113,12 @@ type handler struct {
 	snapSync atomic.Bool // Flag whether snap sync is enabled (gets disabled if we already have blocks)
 	synced   atomic.Bool // Flag whether we're considered synchronised (enables transaction processing)
 
-	database ethdb.Database
-	txpool   txPool
-	chain    *core.BlockChain
-	maxPeers int
+	database       ethdb.Database
+	txpool         txPool
+	chain          *core.BlockChain
+	maxPeers       int
+	forceSyncCycle time.Duration
+	tdSyncInterval time.Duration
 
 	downloader   *downloader.Downloader
 	blockFetcher *fetcher.BlockFetcher
@@ -161,6 +165,8 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		handlerDoneCh:  make(chan struct{}),
 		handlerStartCh: make(chan struct{}),
 		engine:         config.Engine, // ## Quorum QBFT
+		forceSyncCycle: config.ForceSyncCycle,
+		tdSyncInterval: config.TdSyncInterval,
 	}
 
 	// ## Quorum QBFT START

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -161,13 +162,15 @@ func newTestHandlerWithBlocks(blocks int) *testHandler {
 	txpool := newTestTxPool()
 
 	handler, _ := newHandler(&handlerConfig{
-		Database:   db,
-		Chain:      chain,
-		TxPool:     txpool,
-		Merger:     consensus.NewMerger(rawdb.NewMemoryDatabase()),
-		Network:    1,
-		Sync:       downloader.SnapSync,
-		BloomCache: 1,
+		Database:       db,
+		Chain:          chain,
+		TxPool:         txpool,
+		Merger:         consensus.NewMerger(rawdb.NewMemoryDatabase()),
+		Network:        1,
+		Sync:           downloader.SnapSync,
+		ForceSyncCycle: 10 * time.Second,
+		TdSyncInterval: 10 * time.Second,
+		BloomCache:     1,
 	})
 	handler.Start(1000)
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -137,7 +137,7 @@ func (cs *chainSyncer) loop() {
 
 		case <-cs.tdCheckTimer.C:
 			if _, headTD := cs.modeAndLocalHead(); headTD != nil {
-				if cs.previousTD.Cmp(headTD) == 0 {
+				if cs.previousTD != nil && cs.previousTD.Cmp(headTD) == 0 {
 					cs.forceAdjustTD = true
 				}
 				cs.previousTD = new(big.Int).Set(headTD)

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -30,9 +30,7 @@ import (
 )
 
 const (
-	forceSyncCycle      = 10 * time.Second // Time interval to force syncs, even if few peers are available
-	tdCheckInterval     = 30 * time.Second // Time interval to verify TD changes and detect sync stalling
-	defaultMinSyncPeers = 5                // Amount of peers desired to start syncing
+	defaultMinSyncPeers = 5 // Amount of peers desired to start syncing
 )
 
 // syncTransactions starts sending all currently pending transactions to the given peer.
@@ -102,10 +100,10 @@ func (cs *chainSyncer) loop() {
 
 	// The force timer lowers the peer count threshold down to one when it fires.
 	// This ensures we'll always start sync even if there aren't enough peers.
-	cs.force = time.NewTimer(forceSyncCycle)
+	cs.force = time.NewTimer(cs.handler.forceSyncCycle)
 	defer cs.force.Stop()
 
-	cs.tdCheckTimer = time.NewTimer(tdCheckInterval)
+	cs.tdCheckTimer = time.NewTimer(cs.handler.tdSyncInterval)
 	defer cs.tdCheckTimer.Stop()
 
 	_, headTD := cs.modeAndLocalHead()
@@ -124,7 +122,7 @@ func (cs *chainSyncer) loop() {
 			// Peer information changed, recheck.
 		case err := <-cs.doneCh:
 			cs.doneCh = nil
-			cs.force.Reset(forceSyncCycle)
+			cs.force.Reset(cs.handler.forceSyncCycle)
 			cs.forced = false
 
 			// If we've reached the merge transition but no beacon client is available, or
@@ -144,7 +142,7 @@ func (cs *chainSyncer) loop() {
 				}
 				cs.previousTD = new(big.Int).Set(headTD)
 			}
-			cs.tdCheckTimer.Reset(tdCheckInterval)
+			cs.tdCheckTimer.Reset(cs.handler.tdSyncInterval)
 
 		case <-cs.handler.quitSync:
 			// Disable all insertion on the blockchain. This needs to happen before

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -54,6 +54,7 @@ type chainSyncer struct {
 	force       *time.Timer
 	forced      bool // true when force timer fired
 	warned      time.Time
+	lastTD      uint64
 	peerEventCh chan struct{}
 	doneCh      chan error // non-nil when sync is running
 }
@@ -171,6 +172,15 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 		return nil
 	}
 	mode, ourTD := cs.modeAndLocalHead()
+
+	tdAdjustment := int64(1)
+	// if the cs.force.C event is triggered but there's no change in the TD
+	if cs.forced && ourTD.Cmp(new(big.Int).SetUint64(cs.lastTD)) == 0 {
+		tdAdjustment = 0
+	} else {
+		cs.lastTD = ourTD.Uint64()
+	}
+
 	op := peerToSyncOp(mode, peer)
 	if cs.handler.chain.Config().QBFT == nil && op.td.Cmp(ourTD) <= 0 {
 		// We seem to be in sync according to the legacy rules. In the merge
@@ -181,8 +191,8 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 			cs.warned = time.Now()
 		}
 		return nil // We're in sync
-	} else if cs.handler.chain.Config().QBFT != nil && op.td.Cmp(new(big.Int).Add(ourTD, big.NewInt(1))) <= 0 {
-		// in QBFT, we're in sync if the peer's TD is within 1 of our own
+	} else if cs.handler.chain.Config().QBFT != nil && op.td.Cmp(new(big.Int).Add(ourTD, big.NewInt(tdAdjustment))) <= 0 {
+		// in QBFT, we're in sync if the peer's TD is within tdAdjustment of our own
 		return nil
 	}
 	return op

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	forceSyncCycle      = 10 * time.Second // Time interval to force syncs, even if few peers are available
+	tdCheckInterval     = 30 * time.Second // Time interval to verify TD changes and detect sync stalling
 	defaultMinSyncPeers = 5                // Amount of peers desired to start syncing
 )
 
@@ -50,13 +51,15 @@ func (h *handler) syncTransactions(p *eth.Peer) {
 
 // chainSyncer coordinates blockchain sync components.
 type chainSyncer struct {
-	handler     *handler
-	force       *time.Timer
-	forced      bool // true when force timer fired
-	warned      time.Time
-	lastTD      uint64
-	peerEventCh chan struct{}
-	doneCh      chan error // non-nil when sync is running
+	handler       *handler
+	force         *time.Timer
+	forced        bool // true when force timer fired
+	warned        time.Time
+	tdCheckTimer  *time.Timer
+	forceAdjustTD bool
+	previousTD    *big.Int
+	peerEventCh   chan struct{}
+	doneCh        chan error // non-nil when sync is running
 }
 
 // chainSyncOp is a scheduled sync operation.
@@ -102,6 +105,16 @@ func (cs *chainSyncer) loop() {
 	cs.force = time.NewTimer(forceSyncCycle)
 	defer cs.force.Stop()
 
+	cs.tdCheckTimer = time.NewTimer(tdCheckInterval)
+	defer cs.tdCheckTimer.Stop()
+
+	_, headTD := cs.modeAndLocalHead()
+	if headTD != nil {
+		cs.previousTD = new(big.Int).Set(headTD)
+	} else {
+		cs.previousTD = big.NewInt(0)
+	}
+
 	for {
 		if op := cs.nextSyncOp(); op != nil {
 			cs.startSync(op)
@@ -123,6 +136,15 @@ func (cs *chainSyncer) loop() {
 			}
 		case <-cs.force.C:
 			cs.forced = true
+
+		case <-cs.tdCheckTimer.C:
+			if _, headTD := cs.modeAndLocalHead(); headTD != nil {
+				if cs.previousTD.Cmp(headTD) == 0 {
+					cs.forceAdjustTD = true
+				}
+				cs.previousTD = new(big.Int).Set(headTD)
+			}
+			cs.tdCheckTimer.Reset(tdCheckInterval)
 
 		case <-cs.handler.quitSync:
 			// Disable all insertion on the blockchain. This needs to happen before
@@ -173,12 +195,12 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	}
 	mode, ourTD := cs.modeAndLocalHead()
 
+	// Normally, sync starts when the TD gap is 2 or greater.
+	// If forceAdjustTD is active, sync starts even when the gap is just 1.
 	tdAdjustment := int64(1)
-	// if the cs.force.C event is triggered but there's no change in the TD
-	if cs.forced && ourTD.Cmp(new(big.Int).SetUint64(cs.lastTD)) == 0 {
+	if cs.forceAdjustTD {
 		tdAdjustment = 0
-	} else {
-		cs.lastTD = ourTD.Uint64()
+		cs.forceAdjustTD = false
 	}
 
 	op := peerToSyncOp(mode, peer)


### PR DESCRIPTION
Adjusted the sync condition to allow synchronization if the TD difference is at least 1, when there has been no TD change during the configured forceSyncCycle period.