### PR TITLE
WBFT Chain Genesis Allocation Error Handling and Refactored codes.

### DIFF
--- a/consensus/qbft/config.go
+++ b/consensus/qbft/config.go
@@ -208,26 +208,16 @@ func GetStateTransitions(chainConfig *params.ChainConfig, num *big.Int) []params
 }
 
 func getMontBlancTransition(config *params.ChainConfig) params.StateTransition {
-	st := params.StateTransition{
-		Codes: []params.CodeParam{
-			{Address: govwbft.GovConfigAddress, Code: govwbft.GovConfigContract},
-			{Address: govwbft.GovStakingAddress, Code: govwbft.GovStakingContract},
-			{Address: govwbft.GovRewardeeImpAddress, Code: govwbft.GovRewardeeImpContract},
-		},
-		States: []params.StateParam{
-			{Address: govwbft.GovConfigAddress, Key: common.BigToHash(big.NewInt(0)), Value: common.BigToHash((*big.Int)(config.QBFT.GovParams.MinimumStaking))},
-			{Address: govwbft.GovConfigAddress, Key: common.BigToHash(big.NewInt(1)), Value: common.BigToHash((*big.Int)(config.QBFT.GovParams.MaximumStaking))},
-			{Address: govwbft.GovConfigAddress, Key: common.BigToHash(big.NewInt(2)), Value: common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.UnbondingStaker))},
-			{Address: govwbft.GovConfigAddress, Key: common.BigToHash(big.NewInt(3)), Value: common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.UnbondingDelegator))},
-			{Address: govwbft.GovConfigAddress, Key: common.BigToHash(big.NewInt(4)), Value: common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.FeePrecision))},
-			{Address: govwbft.GovConfigAddress, Key: common.BigToHash(big.NewInt(5)), Value: common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.ChangeFeeDelay))},
-			{Address: govwbft.GovConfigAddress, Key: common.BigToHash(big.NewInt(6)), Value: common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.MinStakers))},
-		},
-	}
+
+	codes, states := govwbft.BuildGovTransitionParams(config)
 
 	if config.MontBlanc != nil && len(config.MontBlanc.NCPs) > 0 {
-		st.Codes = append(st.Codes, params.CodeParam{Address: govwbft.GovNCPAddress, Code: govwbft.GovNCPContract})
-		st.States = append(st.States, govwbft.InitializeNCP(config.MontBlanc.NCPs)...)
+		codes = append(codes, params.CodeParam{Address: govwbft.GovNCPAddress, Code: govwbft.GovNCPContract})
+		states = append(states, govwbft.InitializeNCP(config.MontBlanc.NCPs)...)
 	}
-	return st
+
+	return params.StateTransition{
+		Codes:  codes,
+		States: states,
+	}
 }

--- a/consensus/qbft/config.go
+++ b/consensus/qbft/config.go
@@ -208,7 +208,6 @@ func GetStateTransitions(chainConfig *params.ChainConfig, num *big.Int) []params
 }
 
 func getMontBlancTransition(config *params.ChainConfig) params.StateTransition {
-
 	codes, states := govwbft.BuildGovTransitionParams(config)
 
 	if config.MontBlanc != nil && len(config.MontBlanc.NCPs) > 0 {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	govwbft "github.com/ethereum/go-ethereum/wemixgov/governance-wbft"
 	"math/big"
 	"strings"
 
@@ -38,7 +39,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/pathdb"
-	govwbft "github.com/ethereum/go-ethereum/wemixgov/governance-wbft"
 	"github.com/holiman/uint256"
 )
 
@@ -698,33 +698,33 @@ func injectContracts(genesis *Genesis, config *params.ChainConfig) error {
 	if config == nil || config.QBFT == nil || config.QBFT.GovParams == nil {
 		return errors.New("Some or all of the QBFT parameters are missing from the genesis configuration.")
 	}
-	qbftContract := []common.Address{
-		common.HexToAddress(params.GOV_CONFIG_ADDRESS),
-		common.HexToAddress(params.GOV_STAKING_ADDRESS),
-		common.HexToAddress(params.GOV_REWARDEE_IMP_ADDRESS),
+
+	codes, states := govwbft.BuildGovTransitionParams(config)
+
+	if genesis.Alloc == nil {
+		genesis.Alloc = make(map[common.Address]types.Account)
 	}
-	for _, addr := range qbftContract {
-		switch addr {
-		case common.HexToAddress(params.GOV_CONFIG_ADDRESS):
-			if genesis.Alloc == nil {
-				genesis.Alloc = map[common.Address]types.Account{}
-			}
-			genesis.Alloc[addr] = types.Account{Code: hexutil.MustDecode(govwbft.GovConfigContract), Balance: common.Big0, Storage: make(map[common.Hash]common.Hash)}
-			genesis.Alloc[addr].Storage[common.BigToHash(big.NewInt(0))] = common.BigToHash((*big.Int)(config.QBFT.GovParams.MinimumStaking))
-			genesis.Alloc[addr].Storage[common.BigToHash(big.NewInt(1))] = common.BigToHash((*big.Int)(config.QBFT.GovParams.MaximumStaking))
-			genesis.Alloc[addr].Storage[common.BigToHash(big.NewInt(2))] = common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.UnbondingStaker))
-			genesis.Alloc[addr].Storage[common.BigToHash(big.NewInt(3))] = common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.UnbondingDelegator))
-			genesis.Alloc[addr].Storage[common.BigToHash(big.NewInt(4))] = common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.FeePrecision))
-			genesis.Alloc[addr].Storage[common.BigToHash(big.NewInt(5))] = common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.ChangeFeeDelay))
-			genesis.Alloc[addr].Storage[common.BigToHash(big.NewInt(6))] = common.BigToHash(new(big.Int).SetUint64(config.QBFT.GovParams.MinStakers))
 
-		case common.HexToAddress(params.GOV_STAKING_ADDRESS):
-			genesis.Alloc[addr] = types.Account{Code: hexutil.MustDecode(govwbft.GovStakingContract), Balance: common.Big0}
-
-		case common.HexToAddress(params.GOV_REWARDEE_IMP_ADDRESS):
-			genesis.Alloc[addr] = types.Account{Code: hexutil.MustDecode(govwbft.GovRewardeeImpContract), Balance: common.Big0}
+	for _, cp := range codes {
+		acct := genesis.Alloc[cp.Address]
+		acct.Balance = common.Big0
+		acct.Code = hexutil.MustDecode(cp.Code)
+		if acct.Storage == nil {
+			acct.Storage = make(map[common.Hash]common.Hash)
 		}
+		genesis.Alloc[cp.Address] = acct
+
 	}
+
+	for _, sp := range states {
+		acct := genesis.Alloc[sp.Address]
+		//if acct.Storage == nil {
+		//	acct.Storage = make(map[common.Hash]common.Hash)
+		//}
+		acct.Storage[sp.Key] = sp.Value
+		genesis.Alloc[sp.Address] = acct
+	}
+
 	return nil
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	govwbft "github.com/ethereum/go-ethereum/wemixgov/governance-wbft"
 	"math/big"
 	"strings"
 
@@ -39,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
 	"github.com/ethereum/go-ethereum/triedb/pathdb"
+	govwbft "github.com/ethereum/go-ethereum/wemixgov/governance-wbft"
 	"github.com/holiman/uint256"
 )
 
@@ -713,14 +713,10 @@ func injectContracts(genesis *Genesis, config *params.ChainConfig) error {
 			acct.Storage = make(map[common.Hash]common.Hash)
 		}
 		genesis.Alloc[cp.Address] = acct
-
 	}
 
 	for _, sp := range states {
 		acct := genesis.Alloc[sp.Address]
-		//if acct.Storage == nil {
-		//	acct.Storage = make(map[common.Hash]common.Hash)
-		//}
 		acct.Storage[sp.Key] = sp.Value
 		genesis.Alloc[sp.Address] = acct
 	}

--- a/wemixgov/governance-contract/test/gov_bind_test.go
+++ b/wemixgov/governance-contract/test/gov_bind_test.go
@@ -51,6 +51,7 @@ func TestCheckMainnetEnvStorageValues(t *testing.T) {
 	require.NoError(t, err)
 
 	block, err := client.BlockByNumber(ctx, common.Big0)
+
 	require.NoError(t, err)
 
 	callOpts := &bind.CallOpts{Context: ctx}

--- a/wemixgov/governance-wbft/governance.go
+++ b/wemixgov/governance-wbft/governance.go
@@ -1,6 +1,7 @@
 package govwbft
 
 import (
+	"github.com/ethereum/go-ethereum/common/math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -91,4 +92,55 @@ func NCPStakerInfoMap(state StateReader) map[common.Address]Staker {
 		stakerInfos[v] = StakerInfo(state, v)
 	}
 	return stakerInfos
+}
+
+func BuildGovTransitionParams(config *params.ChainConfig) (
+	codes []params.CodeParam,
+	states []params.StateParam,
+) {
+
+	codes = []params.CodeParam{
+		{Address: GovConfigAddress, Code: GovConfigContract},
+		{Address: GovStakingAddress, Code: GovStakingContract},
+		{Address: GovRewardeeImpAddress, Code: GovRewardeeImpContract},
+	}
+
+	gp := config.QBFT.GovParams
+	if gp.MinimumStaking == nil {
+		x, ok := new(big.Int).SetString("69e10de76676d0800000", 16)
+		if !ok {
+			panic("invalid hexadecimal literal")
+		}
+		gp.MinimumStaking = (*math.HexOrDecimal256)(x)
+	}
+	if gp.MaximumStaking == nil {
+		gp.MaximumStaking = (*math.HexOrDecimal256)(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1)))
+	}
+	if gp.UnbondingStaker == 0 {
+		gp.UnbondingStaker = 604800 // 7 days
+	}
+	if gp.UnbondingDelegator == 0 {
+		gp.UnbondingDelegator = 259200 // 3 days
+	}
+	if gp.FeePrecision == 0 {
+		gp.FeePrecision = 10000 // 0.01%
+	}
+	if gp.ChangeFeeDelay == 0 {
+		gp.ChangeFeeDelay = 604800 // 7 days
+	}
+	if gp.MinStakers == 0 {
+		gp.MinStakers = 1
+	}
+
+	states = []params.StateParam{
+		{Address: GovConfigAddress, Key: common.BigToHash(big.NewInt(0)), Value: common.BigToHash((*big.Int)(gp.MinimumStaking))},
+		{Address: GovConfigAddress, Key: common.BigToHash(big.NewInt(1)), Value: common.BigToHash((*big.Int)(gp.MaximumStaking))},
+		{Address: GovConfigAddress, Key: common.BigToHash(big.NewInt(2)), Value: common.BigToHash(new(big.Int).SetUint64(gp.UnbondingStaker))},
+		{Address: GovConfigAddress, Key: common.BigToHash(big.NewInt(3)), Value: common.BigToHash(new(big.Int).SetUint64(gp.UnbondingDelegator))},
+		{Address: GovConfigAddress, Key: common.BigToHash(big.NewInt(4)), Value: common.BigToHash(new(big.Int).SetUint64(gp.FeePrecision))},
+		{Address: GovConfigAddress, Key: common.BigToHash(big.NewInt(5)), Value: common.BigToHash(new(big.Int).SetUint64(gp.ChangeFeeDelay))},
+		{Address: GovConfigAddress, Key: common.BigToHash(big.NewInt(6)), Value: common.BigToHash(new(big.Int).SetUint64(gp.MinStakers))},
+	}
+
+	return
 }

--- a/wemixgov/governance-wbft/governance.go
+++ b/wemixgov/governance-wbft/governance.go
@@ -1,10 +1,10 @@
 package govwbft
 
 import (
-	"github.com/ethereum/go-ethereum/common/math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -98,7 +98,6 @@ func BuildGovTransitionParams(config *params.ChainConfig) (
 	codes []params.CodeParam,
 	states []params.StateParam,
 ) {
-
 	codes = []params.CodeParam{
 		{Address: GovConfigAddress, Code: GovConfigContract},
 		{Address: GovStakingAddress, Code: GovStakingContract},


### PR DESCRIPTION
### Purpose
- Some fields in govParams in Genesis.json should also be honored as default values if they are missing
- Refactoring code related to genesis Commits

### Modified
- Refactored injectContracts , getMontBlancTransition, and BuildGovTransitionParams functions to set default values if some fields related to govnarance are missing.

### Tests
- [x] If I use an address used by wbft chain in genesis.json, such as 1000, in alloc, it should output an error and not proceed.
- [x] Whether it starts correctly after copying chaindata of other node
- [x] Does node behavior after deleting ancient db work correctly?
- [x] whether there are no issues in common node restart scenarios
- [x] the dump genesis command works correctly and the genesis.json file is extracted correctly.  
- [x] Test code works without problems
- [x] config const lookup with web3 api is retrieved correctly and values are written correctly
- [x] After deleting the variables of govparam in the genesis file, does the node run normally with default config?  