### PR TITLE
fix: modified node_info response values to be protocol-specific

### DIFF
--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -108,7 +108,24 @@ func MakeProtocols(backend Backend, network uint64, dnsdisc enode.Iterator) []p2
 				})
 			},
 			NodeInfo: func() interface{} {
-				return nodeInfo(backend.Chain(), network)
+				original := backend.Chain().Config()
+				copied := *original
+				if original.QBFT != nil {
+					qbftCopy := *original.QBFT
+					copied.QBFT = &qbftCopy
+				}
+				if original.MontBlanc != nil {
+					mbCopy := *original.MontBlanc
+					copied.MontBlanc = &mbCopy
+				}
+
+				copied.QBFT = nil
+				copied.MontBlanc = nil
+
+				eth_nodeInfo := nodeInfo(backend.Chain(), network)
+				eth_nodeInfo.Config = &copied
+
+				return eth_nodeInfo
 			},
 			PeerInfo: func(id enode.ID) interface{} {
 				return backend.PeerInfo(id)

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -108,21 +108,11 @@ func MakeProtocols(backend Backend, network uint64, dnsdisc enode.Iterator) []p2
 				})
 			},
 			NodeInfo: func() interface{} {
-				original := backend.Chain().Config()
-				copied := *original
-				if original.QBFT != nil {
-					qbftCopy := *original.QBFT
-					copied.QBFT = &qbftCopy
-				}
-				if original.MontBlanc != nil {
-					mbCopy := *original.MontBlanc
-					copied.MontBlanc = &mbCopy
-				}
-
+				// Create a copy of the node info to avoid data sharing
+				eth_nodeInfo := nodeInfo(backend.Chain(), network)
+				copied := *eth_nodeInfo.Config
 				copied.QBFT = nil
 				copied.MontBlanc = nil
-
-				eth_nodeInfo := nodeInfo(backend.Chain(), network)
 				eth_nodeInfo.Config = &copied
 
 				return eth_nodeInfo


### PR DESCRIPTION
### Purpose
- When calling the Node_info function, the response value should be protocol-specific.

### Modified
- Modified two protocols (“eth, istanbul”) with the same response value by referencing the same configuration to have the response value specific to each protocol.

### Tests
- [x] Call admin.nodeinfo to check the response value