### PR TITLE
fix: discard prepared block and seals if proposal is blacklisted

### DIFF
--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -261,6 +261,14 @@ func (c *Core) startNewRound(round *big.Int) {
 // updateRoundState updates round state by checking if locking block is necessary
 func (c *Core) updateRoundState(nextValSet wbft.ValidatorSet, view *wbft.View, roundChange bool) {
 	if roundChange && c.current != nil {
+		if c.current.preparedBlock != nil && c.backend.HasBadProposal(c.current.preparedBlock.Hash()) {
+			c.currentLogger(false, nil).Warn("[QBFT] Discarding prepared block due to bad proposal", "hash", c.current.preparedBlock.Hash())
+			// clear prepared round and block if we have a bad proposal
+			c.current.preparedRound = nil
+			c.current.preparedBlock = nil
+			// clear prepare and commit seals for the current sequence
+			c.ClearExtraSeals(new(big.Int).Add(c.current.sequence, common.Big1))
+		}
 		c.current = newRoundState(view, nextValSet, c.current.Preprepare, c.current.preparedRound, c.current.preparedBlock, c.current.pendingRequest, c.backend.HasBadProposal)
 	} else {
 		if c.current != nil {


### PR DESCRIPTION
Discard preparedRound and preparedBlock during round change  if the previously prepared proposal has been blacklisted.
This prevents the new proposer from reusing a blacklisted proposal,
which could otherwise lead to block finalization failure due to a merkle root mismatch and halt the chain.

This fix addresses the following issue :

- A malicious validator proposes a tampered proposal (e.g., manipulated reward).
- The network reaches consensus on the proposal, but during the Finalize phase, the block is rejected due to a state mismatch.
- In the next round, the same proposal is reused(by the lock mechanism), causing block production to stop.

Additionally, any prepare and commit seals associated with the blacklisted proposal are also cleared.