### PR TITLE
fix: reject PRE-PREPARE with mismatched sequence and proposal number

### DIFF
--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -122,6 +122,12 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 		return errNotFromProposer
 	}
 
+	// Reject if sequence ≠ proposal number
+	if preprepare.Sequence.Uint64() != preprepare.Proposal.Number().Uint64() {
+		logger.Warn("WBFT: ignore PRE-PREPARE with mismatched sequence and proposal number")
+		return errInvalidPreparedBlock
+	}
+
 	// Validates PRE-PREPARE message justification
 	if preprepare.Round.Uint64() > 0 {
 		if err := isJustified(preprepare.Proposal, preprepare.JustificationRoundChanges, preprepare.JustificationPrepares, c.valSet.QuorumSize()); err != nil {


### PR DESCRIPTION
Add validation to reject PRE-PREPARE messages with mismatched sequence and block number.