### PR TITLE
fix: correct TransactionHistory and TxLookupLimit for 1s block time

### DIFF
--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -65,8 +65,8 @@ var Defaults = Config{
 	TdSyncInterval: common.Duration(10 * time.Second), // Time interval to verify TD changes and detect sync stalling
 
 	NetworkId:          0, // enable auto configuration of networkID == chainID
-	TxLookupLimit:      2350000,
-	TransactionHistory: 2350000,
+	TxLookupLimit:      31536000,
+	TransactionHistory: 31536000,
 	StateHistory:       params.FullImmutabilityThreshold,
 	LightPeers:         100,
 	DatabaseCache:      512,


### PR DESCRIPTION
Updated the default transaction index retention period to one year, assuming a 1-second block generation time.

- TransactionHistory: 2,350,000 → 31,536,000
- Also updated TxLookupLimit to the same value for backward compatibility