### PR TITLE
feat: round change retry

### DIFF
--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -88,6 +88,7 @@ type Core struct {
 	events                *event.TypeMuxSubscription
 	finalCommittedSub     *event.TypeMuxSubscription
 	timeoutSub            *event.TypeMuxSubscription
+	retryTimeoutSub       *event.TypeMuxSubscription
 	futurePreprepareTimer *time.Timer
 
 	valSet     wbft.ValidatorSet
@@ -108,6 +109,8 @@ type Core struct {
 	roundChangeSet          *roundChangeSet
 	roundChangeTimer        *time.Timer
 	lastSentTimeoutCanceled *bool
+
+	retryRoundChangeTimer *time.Timer
 
 	WBFTPreparedPrepares []*wbftmessage.Prepare
 
@@ -363,6 +366,27 @@ func (c *Core) newRoundChangeTimer() {
 	*c.lastSentTimeoutCanceled = false
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
 		c.sendEvent(timeoutEvent{c.lastSentTimeoutCanceled})
+	})
+}
+
+// stopRetryTimer stops the round-change retry timer if running.
+func (c *Core) stopRetryTimer() {
+	if c.retryRoundChangeTimer != nil {
+		c.retryRoundChangeTimer.Stop()
+	}
+}
+
+// newRetryRoundChangeTimer sets a retry timer to reattempt round-change after a timeout
+func (c *Core) newRetryRoundChangeTimer() {
+	c.stopRetryTimer()
+
+	// set timeout based on the round number
+	cfg := c.config.GetConfig(c.current.Sequence())
+	timeout := time.Duration(cfg.RequestTimeout) * time.Millisecond
+
+	c.currentLogger(true, nil).Trace("WBFT: set ROUND-CHANGE retry timer", "round", c.current.Round(), "timeout", timeout.Seconds())
+	c.roundChangeTimer = time.AfterFunc(timeout, func() {
+		c.sendEvent(retryTimeoutEvent{})
 	})
 }
 

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -110,7 +110,7 @@ type Core struct {
 	roundChangeTimer        *time.Timer
 	lastSentTimeoutCanceled *bool
 
-	retryRoundChangeTimer *time.Timer
+	retrySendingRoundChangeTimer *time.Timer
 
 	WBFTPreparedPrepares []*wbftmessage.Prepare
 
@@ -378,24 +378,24 @@ func (c *Core) newRoundChangeTimer() {
 	})
 }
 
-// stopRetryTimer stops the round-change retry timer if running.
-func (c *Core) stopRetryTimer() {
-	if c.retryRoundChangeTimer != nil {
-		c.retryRoundChangeTimer.Stop()
+// stopRetrySendingRoundChangeTimer stops the round-change retry timer if running.
+func (c *Core) stopRetrySendingRoundChangeTimer() {
+	if c.retrySendingRoundChangeTimer != nil {
+		c.retrySendingRoundChangeTimer.Stop()
 	}
 }
 
-// newRetryRoundChangeTimer sets a retry timer to reattempt round-change after a timeout
-func (c *Core) newRetryRoundChangeTimer() {
-	c.stopRetryTimer()
+// newRetrySendingRoundChangeTimer sets a retry timer to reattempt round-change after a timeout
+func (c *Core) newRetrySendingRoundChangeTimer() {
+	c.stopRetrySendingRoundChangeTimer()
 
 	// set timeout based on the round number
 	cfg := c.config.GetConfig(c.current.Sequence())
 	timeout := time.Duration(cfg.RequestTimeout) * time.Millisecond
 
 	c.currentLogger(true, nil).Trace("WBFT: set ROUND-CHANGE retry timer", "round", c.current.Round(), "timeout", timeout.Seconds())
-	c.retryRoundChangeTimer = time.AfterFunc(timeout, func() {
-		c.sendEvent(retryTimeoutEvent{})
+	c.retrySendingRoundChangeTimer = time.AfterFunc(timeout, func() {
+		c.sendEvent(retryTimeoutEvent{c.current.Round()})
 	})
 }
 

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -314,6 +314,10 @@ func (c *Core) stopFuturePreprepareTimer() {
 
 func (c *Core) stopTimer() {
 	c.stopFuturePreprepareTimer()
+
+	// Stop retry sending ROUND-CHANGE retry timer
+	c.stopRetrySendingRoundChangeTimer()
+
 	if c.roundChangeTimer != nil {
 		c.roundChangeTimer.Stop()
 	}

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -350,7 +350,7 @@ func (c *Core) newRoundChangeTimer() {
 		}
 		// prevent log storm when unexpected overflow happens
 		if timeout < baseTimeout {
-			c.currentLogger(true, nil).Error("WBFT: Possible request timeout overflow detected, setting timeout value to maxRequestTimeout",
+			c.currentLogger(true, nil).Warn("WBFT: Possible request timeout overflow detected, setting timeout value to maxRequestTimeout",
 				"timeout", timeout.Seconds(),
 				"max_request_timeout", maxRequestTimeout.Seconds(),
 			)
@@ -360,7 +360,7 @@ func (c *Core) newRoundChangeTimer() {
 		timeoutFloat64 := math.Pow(2, float64(round)) * float64(baseTimeout)
 
 		if math.IsNaN(timeoutFloat64) || math.IsInf(timeoutFloat64, 0) || timeoutFloat64 > float64(math.MaxInt64) {
-			c.currentLogger(true, nil).Error("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
+			c.currentLogger(true, nil).Warn("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
 				"round", round,
 				"adjusted_timeout", time.Duration(math.MaxInt64).Seconds(),
 			)

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -394,7 +394,7 @@ func (c *Core) newRetryRoundChangeTimer() {
 	timeout := time.Duration(cfg.RequestTimeout) * time.Millisecond
 
 	c.currentLogger(true, nil).Trace("WBFT: set ROUND-CHANGE retry timer", "round", c.current.Round(), "timeout", timeout.Seconds())
-	c.roundChangeTimer = time.AfterFunc(timeout, func() {
+	c.retryRoundChangeTimer = time.AfterFunc(timeout, func() {
 		c.sendEvent(retryTimeoutEvent{})
 	})
 }

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -357,8 +357,17 @@ func (c *Core) newRoundChangeTimer() {
 			timeout = maxRequestTimeout
 		}
 	} else {
-		// effectively impossible to observe overflow happen when maxRequestTimeout is disabled
-		timeout = baseTimeout * time.Duration(math.Pow(2, float64(round)))
+		timeoutFloat64 := math.Pow(2, float64(round)) * float64(baseTimeout)
+
+		if timeoutFloat64 > float64(math.MaxInt64) {
+			c.currentLogger(true, nil).Error("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
+				"round", round,
+				"adjusted_timeout", time.Duration(math.MaxInt64).Seconds(),
+			)
+			timeout = time.Duration(math.MaxInt64)
+		} else {
+			timeout = time.Duration(timeoutFloat64)
+		}
 	}
 
 	c.currentLogger(true, nil).Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -359,14 +359,14 @@ func (c *Core) newRoundChangeTimer() {
 	} else {
 		timeoutFloat64 := math.Pow(2, float64(round)) * float64(baseTimeout)
 
-		if timeoutFloat64 > float64(math.MaxInt64) {
+		if math.IsNaN(timeoutFloat64) || math.IsInf(timeoutFloat64, 0) || timeoutFloat64 > float64(math.MaxInt64) {
 			c.currentLogger(true, nil).Error("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
 				"round", round,
 				"adjusted_timeout", time.Duration(math.MaxInt64).Seconds(),
 			)
 			timeout = time.Duration(math.MaxInt64)
 		} else {
-			timeout = time.Duration(timeoutFloat64)
+			timeout = time.Duration(int64(timeoutFloat64))
 		}
 	}
 

--- a/consensus/wbft/core/events.go
+++ b/consensus/wbft/core/events.go
@@ -21,6 +21,8 @@
 package core
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/consensus/wbft"
 	wbfmessage "github.com/ethereum/go-ethereum/consensus/wbft/messages"
 )
@@ -34,4 +36,6 @@ type timeoutEvent struct {
 	canceled *bool
 }
 
-type retryTimeoutEvent struct{}
+type retryTimeoutEvent struct {
+	round *big.Int
+}

--- a/consensus/wbft/core/events.go
+++ b/consensus/wbft/core/events.go
@@ -33,3 +33,5 @@ type backlogEvent struct {
 type timeoutEvent struct {
 	canceled *bool
 }
+
+type retryTimeoutEvent struct{}

--- a/consensus/wbft/core/final_committed.go
+++ b/consensus/wbft/core/final_committed.go
@@ -20,10 +20,15 @@
 
 package core
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
 
 func (c *Core) handleFinalCommittedMsg() error {
 	c.currentLogger(true, nil).Info("WBFT: handle final committed")
 	c.startNewRound(common.Big0)
+
+	// Stop ROUND-CHANGE retry timer
+	c.stopRetryTimer()
 	return nil
 }

--- a/consensus/wbft/core/final_committed.go
+++ b/consensus/wbft/core/final_committed.go
@@ -29,6 +29,6 @@ func (c *Core) handleFinalCommittedMsg() error {
 	c.startNewRound(common.Big0)
 
 	// Stop ROUND-CHANGE retry timer
-	c.stopRetryTimer()
+	c.stopRetrySendingRoundChangeTimer()
 	return nil
 }

--- a/consensus/wbft/core/final_committed.go
+++ b/consensus/wbft/core/final_committed.go
@@ -27,8 +27,5 @@ import (
 func (c *Core) handleFinalCommittedMsg() error {
 	c.currentLogger(true, nil).Info("WBFT: handle final committed")
 	c.startNewRound(common.Big0)
-
-	// Stop ROUND-CHANGE retry timer
-	c.stopRetrySendingRoundChangeTimer()
 	return nil
 }

--- a/consensus/wbft/core/handler.go
+++ b/consensus/wbft/core/handler.go
@@ -75,6 +75,9 @@ func (c *Core) subscribeEvents() {
 	c.finalCommittedSub = c.backend.EventMux().Subscribe(
 		wbft.FinalCommittedEvent{},
 	)
+	c.retryTimeoutSub = c.backend.EventMux().Subscribe(
+		retryTimeoutEvent{},
+	)
 }
 
 // Unsubscribe all events
@@ -82,6 +85,7 @@ func (c *Core) unsubscribeEvents() {
 	c.events.Unsubscribe()
 	c.timeoutSub.Unsubscribe()
 	c.finalCommittedSub.Unsubscribe()
+	c.retryTimeoutSub.Unsubscribe()
 }
 
 // handleEvents starts main wbft handler loop that processes all incoming messages
@@ -162,6 +166,16 @@ func (c *Core) handleEvents() {
 			switch event.Data.(type) {
 			case wbft.FinalCommittedEvent:
 				c.handleFinalCommittedMsg()
+			}
+		case event, ok := <-c.retryTimeoutSub.Chan():
+			// handle round-change retry timeout event
+			if !ok {
+				return
+			}
+			switch event.Data.(type) {
+			case retryTimeoutEvent:
+				// on round-change retry timeout, re-broadcast round-change message for the same round
+				c.broadcastRetryRoundChange()
 			}
 		}
 	}

--- a/consensus/wbft/core/handler.go
+++ b/consensus/wbft/core/handler.go
@@ -172,10 +172,9 @@ func (c *Core) handleEvents() {
 			if !ok {
 				return
 			}
-			switch event.Data.(type) {
-			case retryTimeoutEvent:
-				// on round-change retry timeout, re-broadcast round-change message for the same round
-				c.broadcastRetryRoundChange()
+			if e, ok := event.Data.(retryTimeoutEvent); ok {
+				// Re-broadcast round-change message for the same round on retry timeout
+				c.broadcastRoundChange(e.round)
 			}
 		}
 	}

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -166,8 +166,8 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 		c.newRoundChangeTimer()
 		c.consensusTimestamp = time.Now()
 
-		// Stop ROUND-CHANGE retry timer
-		c.stopRetryTimer()
+		// Stop retry sending ROUND-CHANGE retry timer
+		c.stopRetrySendingRoundChangeTimer()
 
 		// Update current state
 		c.current.SetPreprepare(preprepare)

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -166,6 +166,9 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 		c.newRoundChangeTimer()
 		c.consensusTimestamp = time.Now()
 
+		// Stop ROUND-CHANGE retry timer
+		c.stopRetryTimer()
+
 		// Update current state
 		c.current.SetPreprepare(preprepare)
 		c.setState(StatePreprepared)

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -166,9 +166,6 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 		c.newRoundChangeTimer()
 		c.consensusTimestamp = time.Now()
 
-		// Stop retry sending ROUND-CHANGE retry timer
-		c.stopRetrySendingRoundChangeTimer()
-
 		// Update current state
 		c.current.SetPreprepare(preprepare)
 		c.setState(StatePreprepared)

--- a/consensus/wbft/core/roundchange.go
+++ b/consensus/wbft/core/roundchange.go
@@ -41,12 +41,6 @@ func (c *Core) broadcastNextRoundChange() {
 	c.broadcastRoundChange(new(big.Int).Add(cv.Round, common.Big1))
 }
 
-// broadcastRetryRoundChange re-sends ROUND-CHANGE message for the current round
-func (c *Core) broadcastRetryRoundChange() {
-	cv := c.currentView()
-	c.broadcastRoundChange(cv.Round)
-}
-
 // broadcastRoundChange is called when either
 // - ROUND-CHANGE timeout expires (meaning either we have not received PRE-PREPARE message or we have not received a quorum of COMMIT messages)
 // -
@@ -55,7 +49,7 @@ func (c *Core) broadcastRetryRoundChange() {
 // - Creates and sign ROUND-CHANGE message
 // - broadcast the ROUND-CHANGE message with the given round
 func (c *Core) broadcastRoundChange(round *big.Int) {
-	c.newRetryRoundChangeTimer()
+	c.newRetrySendingRoundChangeTimer()
 	logger := c.currentLogger(true, nil)
 
 	// Validates new round corresponds to current view

--- a/consensus/wbft/core/roundchange.go
+++ b/consensus/wbft/core/roundchange.go
@@ -153,7 +153,6 @@ func (c *Core) handleRoundChangeMsg(roundChange *wbfmessage.RoundChange) error {
 
 		c.startNewRound(newRound)
 		c.broadcastRoundChange(newRound)
-
 	} else if currentRoundMessages >= c.valSet.QuorumSize() && c.IsProposer() && c.current.preprepareSent.Cmp(currentRound) < 0 {
 		logger.Info("WBFT: received quorum of ROUND-CHANGE messages")
 

--- a/consensus/wbft/core/roundchange.go
+++ b/consensus/wbft/core/roundchange.go
@@ -41,6 +41,12 @@ func (c *Core) broadcastNextRoundChange() {
 	c.broadcastRoundChange(new(big.Int).Add(cv.Round, common.Big1))
 }
 
+// broadcastRetryRoundChange re-sends ROUND-CHANGE message for the current round
+func (c *Core) broadcastRetryRoundChange() {
+	cv := c.currentView()
+	c.broadcastRoundChange(cv.Round)
+}
+
 // broadcastRoundChange is called when either
 // - ROUND-CHANGE timeout expires (meaning either we have not received PRE-PREPARE message or we have not received a quorum of COMMIT messages)
 // -
@@ -49,6 +55,7 @@ func (c *Core) broadcastNextRoundChange() {
 // - Creates and sign ROUND-CHANGE message
 // - broadcast the ROUND-CHANGE message with the given round
 func (c *Core) broadcastRoundChange(round *big.Int) {
+	c.newRetryRoundChangeTimer()
 	logger := c.currentLogger(true, nil)
 
 	// Validates new round corresponds to current view
@@ -146,6 +153,7 @@ func (c *Core) handleRoundChangeMsg(roundChange *wbfmessage.RoundChange) error {
 
 		c.startNewRound(newRound)
 		c.broadcastRoundChange(newRound)
+
 	} else if currentRoundMessages >= c.valSet.QuorumSize() && c.IsProposer() && c.current.preprepareSent.Cmp(currentRound) < 0 {
 		logger.Info("WBFT: received quorum of ROUND-CHANGE messages")
 


### PR DESCRIPTION
Prevents ROUND-CHANGE timeout overflow, and adds a retry mechanism to periodically re-broadcast ROUND-CHANGE messages when consensus is stalled
- The retry interval follows requestTimeoutSeconds defined in the genesis.json