### PR TITLE
fix: future msg drop

### DIFF
--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -47,13 +47,13 @@ const (
 )
 
 // isSequenceTooFarAhead returns true if the sequence difference exceeds the threshold
-func isSequenceTooFarAhead(viewSeq, currSeq *big.Int, threshold int64) (*big.Int, bool) {
+func (c *Core) isSequenceTooFarAhead(viewSeq, currSeq *big.Int, threshold int64) (*big.Int, bool) {
 	seqDiff := new(big.Int).Sub(viewSeq, currSeq)
 	return seqDiff, seqDiff.Cmp(big.NewInt(threshold)) >= 0
 }
 
 // isRoundTooFarAhead returns true if the round difference exceeds the threshold
-func isRoundTooFarAhead(viewRound, currRound *big.Int, threshold int64) (*big.Int, bool) {
+func (c *Core) isRoundTooFarAhead(viewRound, currRound *big.Int, threshold int64) (*big.Int, bool) {
 	roundDiff := new(big.Int).Sub(viewRound, currRound)
 	return roundDiff, roundDiff.Cmp(big.NewInt(threshold)) >= 0
 }
@@ -66,7 +66,7 @@ func (c *Core) dropFutureTooFarMessage(view *wbft.View) bool {
 
 	if view.Sequence.Cmp(curr.Sequence) > 0 {
 		// In the initial phase of block consensus, a message with a sequence number one higher than the current sequence may be received.
-		if seqDiff, tooFar := isSequenceTooFarAhead(view.Sequence, curr.Sequence, sequenceThreshold); tooFar {
+		if seqDiff, tooFar := c.isSequenceTooFarAhead(view.Sequence, curr.Sequence, sequenceThreshold); tooFar {
 			c.logger.Trace("WBFT: future message too far ahead in sequence, dropped",
 				"msg_seq", view.Sequence.String(),
 				"curr_seq", curr.Sequence.String(),
@@ -77,7 +77,7 @@ func (c *Core) dropFutureTooFarMessage(view *wbft.View) bool {
 	}
 
 	if view.Sequence.Cmp(curr.Sequence) == 0 && view.Round.Cmp(curr.Round) > 0 {
-		if roundDiff, tooFar := isRoundTooFarAhead(view.Round, curr.Round, roundThreshold); tooFar {
+		if roundDiff, tooFar := c.isRoundTooFarAhead(view.Round, curr.Round, roundThreshold); tooFar {
 			c.logger.Trace("WBFT: future message too far ahead in round, dropped",
 				"msg_round", view.Round.String(),
 				"curr_round", curr.Round.String(),

--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -41,9 +41,10 @@ var (
 	}
 )
 
-// isFutureSequence returns true if viewSeq is greater than currSeq
-func isFutureSequence(viewSeq, currSeq *big.Int) bool {
-	return viewSeq.Cmp(currSeq) > 0
+// isSequenceTooFarAhead returns true if the sxequence difference exceeds the threshold
+func isSequenceTooFarAhead(viewSeq, currSeq *big.Int, threshold int64) (*big.Int, bool) {
+	seqDiff := new(big.Int).Sub(viewSeq, currSeq)
+	return seqDiff, seqDiff.Cmp(big.NewInt(threshold)) >= 0
 }
 
 // isRoundTooFarAhead returns true if the round difference exceeds the threshold
@@ -56,12 +57,16 @@ func isRoundTooFarAhead(viewRound, currRound *big.Int, threshold int64) (*big.In
 func (c *Core) dropFutureMessage(view *wbft.View) bool {
 	curr := c.currentView()
 
-	if isFutureSequence(view.Sequence, curr.Sequence) {
-		c.logger.Warn("WBFT: future message too far ahead in sequence, dropped",
-			"msg_seq", view.Sequence.String(),
-			"curr_seq", curr.Sequence.String(),
-		)
-		return true
+	if view.Sequence.Cmp(curr.Sequence) > 0 {
+		// In the initial phase of block consensus, a message with a sequence number one higher than the current sequence may be received.
+		if seqDiff, tooFar := isSequenceTooFarAhead(view.Sequence, curr.Sequence, 1); tooFar {
+			c.logger.Warn("WBFT: future message too far ahead in sequence, dropped",
+				"msg_seq", view.Sequence.String(),
+				"curr_seq", curr.Sequence.String(),
+				"diff", seqDiff.String(),
+			)
+			return true
+		}
 	}
 
 	if view.Sequence.Cmp(curr.Sequence) == 0 && view.Round.Cmp(curr.Round) > 0 {
@@ -164,6 +169,61 @@ func (c *Core) checkMessage(msgCode uint64, view *wbft.View) error {
 	}
 	return nil
 }
+
+// 필요 할까?
+// const (
+// 	maxBacklogPerPeer = 30   // 피어당(소스) 최대 백로그 수
+// 	maxTotalBacklog   = 1000 // 전체 최대 백로그 수
+// )
+
+// func (c *Core) addToBacklog(msg wbfmessage.WBFTMessage) {
+// 	logger := c.currentLogger(true, msg)
+// 	src := msg.Source()
+// 	if src == c.Address() {
+// 		logger.Warn("WBFT: backlog from self")
+// 		return
+// 	}
+
+// 	c.backlogsMu.Lock()
+// 	defer c.backlogsMu.Unlock()
+
+// 	// 총 개수 계산
+// 	total := 0
+// 	for _, b := range c.backlogs {
+// 		total += b.Size()
+// 	}
+
+// 	backlog := c.backlogs[src]
+// 	if backlog == nil {
+// 		backlog = prque.New[int64, wbfmessage.WBFTMessage](nil)
+// 		c.backlogs[src] = backlog
+// 	}
+
+// 	// maxBacklogPerPeer 체크
+// 	if backlog.Size() >= maxBacklogPerPeer {
+// 		logger.Warn("WBFT: per-peer backlog limit reached, dropping message",
+// 			"peer", src,
+// 			"limit", maxBacklogPerPeer,
+// 			"code", msg.Code())
+// 		return
+// 	}
+
+// 	//maxTotalBacklog
+// 	if total >= maxTotalBacklog {
+// 		logger.Warn("WBFT: total backlog limit reached, dropping message",
+// 			"total", total,
+// 			"limit", maxTotalBacklog,
+// 			"peer", src,
+// 			"code", msg.Code())
+// 		return
+// 	}
+
+// 	// 백로그에 메시지 추가
+// 	view := msg.View()
+// 	backlog.Push(msg, toNegatePriority(msg.Code(), &view))
+// 	//total+1 : backlog.Push(msg) 호출 후 개수 반영
+// 	logger.Trace("WBFT: backlog message added", "peer", src, "backlog_size", backlog.Size(), "total_backlog", total+1)
+// }
 
 // addToBacklog allows to postpone the processing of future messages
 

--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -179,61 +179,6 @@ func (c *Core) checkMessage(msgCode uint64, view *wbft.View) error {
 	return nil
 }
 
-// 필요 할까?
-// const (
-// 	maxBacklogPerPeer = 30   // 피어당(소스) 최대 백로그 수
-// 	maxTotalBacklog   = 1000 // 전체 최대 백로그 수
-// )
-
-// func (c *Core) addToBacklog(msg wbfmessage.WBFTMessage) {
-// 	logger := c.currentLogger(true, msg)
-// 	src := msg.Source()
-// 	if src == c.Address() {
-// 		logger.Warn("WBFT: backlog from self")
-// 		return
-// 	}
-
-// 	c.backlogsMu.Lock()
-// 	defer c.backlogsMu.Unlock()
-
-// 	// 총 개수 계산
-// 	total := 0
-// 	for _, b := range c.backlogs {
-// 		total += b.Size()
-// 	}
-
-// 	backlog := c.backlogs[src]
-// 	if backlog == nil {
-// 		backlog = prque.New[int64, wbfmessage.WBFTMessage](nil)
-// 		c.backlogs[src] = backlog
-// 	}
-
-// 	// maxBacklogPerPeer 체크
-// 	if backlog.Size() >= maxBacklogPerPeer {
-// 		logger.Warn("WBFT: per-peer backlog limit reached, dropping message",
-// 			"peer", src,
-// 			"limit", maxBacklogPerPeer,
-// 			"code", msg.Code())
-// 		return
-// 	}
-
-// 	//maxTotalBacklog
-// 	if total >= maxTotalBacklog {
-// 		logger.Warn("WBFT: total backlog limit reached, dropping message",
-// 			"total", total,
-// 			"limit", maxTotalBacklog,
-// 			"peer", src,
-// 			"code", msg.Code())
-// 		return
-// 	}
-
-// 	// 백로그에 메시지 추가
-// 	view := msg.View()
-// 	backlog.Push(msg, toNegatePriority(msg.Code(), &view))
-// 	//total+1 : backlog.Push(msg) 호출 후 개수 반영
-// 	logger.Trace("WBFT: backlog message added", "peer", src, "backlog_size", backlog.Size(), "total_backlog", total+1)
-// }
-
 // addToBacklog allows to postpone the processing of future messages
 
 // it adds the message to backlog which is read on every state change

--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -41,7 +41,12 @@ var (
 	}
 )
 
-// isSequenceTooFarAhead returns true if the sxequence difference exceeds the threshold
+const (
+	sequenceThreshold = 1  // Allow up to 1 future sequence
+	roundThreshold    = 10 // Allow up to 10 future rounds
+)
+
+// isSequenceTooFarAhead returns true if the sequence difference exceeds the threshold
 func isSequenceTooFarAhead(viewSeq, currSeq *big.Int, threshold int64) (*big.Int, bool) {
 	seqDiff := new(big.Int).Sub(viewSeq, currSeq)
 	return seqDiff, seqDiff.Cmp(big.NewInt(threshold)) >= 0
@@ -53,14 +58,16 @@ func isRoundTooFarAhead(viewRound, currRound *big.Int, threshold int64) (*big.In
 	return roundDiff, roundDiff.Cmp(big.NewInt(threshold)) >= 0
 }
 
-// dropFutureMessage filters out messages too far ahead in sequence or round
-func (c *Core) dropFutureMessage(view *wbft.View) bool {
+// dropFutureTooFarMessage filters out messages too far ahead in sequence or round
+// This function prevents the node from processing messages that are excessively ahead,
+// which could disrupt the normal flow of the consensus process
+func (c *Core) dropFutureTooFarMessage(view *wbft.View) bool {
 	curr := c.currentView()
 
 	if view.Sequence.Cmp(curr.Sequence) > 0 {
 		// In the initial phase of block consensus, a message with a sequence number one higher than the current sequence may be received.
-		if seqDiff, tooFar := isSequenceTooFarAhead(view.Sequence, curr.Sequence, 1); tooFar {
-			c.logger.Warn("WBFT: future message too far ahead in sequence, dropped",
+		if seqDiff, tooFar := isSequenceTooFarAhead(view.Sequence, curr.Sequence, sequenceThreshold); tooFar {
+			c.logger.Trace("WBFT: future message too far ahead in sequence, dropped",
 				"msg_seq", view.Sequence.String(),
 				"curr_seq", curr.Sequence.String(),
 				"diff", seqDiff.String(),
@@ -70,8 +77,8 @@ func (c *Core) dropFutureMessage(view *wbft.View) bool {
 	}
 
 	if view.Sequence.Cmp(curr.Sequence) == 0 && view.Round.Cmp(curr.Round) > 0 {
-		if roundDiff, tooFar := isRoundTooFarAhead(view.Round, curr.Round, 10); tooFar {
-			c.logger.Warn("WBFT: future message too far ahead in round, dropped",
+		if roundDiff, tooFar := isRoundTooFarAhead(view.Round, curr.Round, roundThreshold); tooFar {
+			c.logger.Trace("WBFT: future message too far ahead in round, dropped",
 				"msg_round", view.Round.String(),
 				"curr_round", curr.Round.String(),
 				"diff", roundDiff.String(),
@@ -98,7 +105,9 @@ func (c *Core) checkMessage(msgCode uint64, view *wbft.View) error {
 		return errInvalidMessage
 	}
 
-	if c.dropFutureMessage(view) {
+	// Drop the message if the view's sequence or round number is too far ahead
+	// This prevents processing of messages that may disrupt consensus due to excessive lead
+	if c.dropFutureTooFarMessage(view) {
 		return errFutureViewTooFar
 	}
 

--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -41,6 +41,43 @@ var (
 	}
 )
 
+// isFutureSequence returns true if viewSeq is greater than currSeq
+func isFutureSequence(viewSeq, currSeq *big.Int) bool {
+	return viewSeq.Cmp(currSeq) > 0
+}
+
+// isRoundTooFarAhead returns true if the round difference exceeds the threshold
+func isRoundTooFarAhead(viewRound, currRound *big.Int, threshold int64) (*big.Int, bool) {
+	roundDiff := new(big.Int).Sub(viewRound, currRound)
+	return roundDiff, roundDiff.Cmp(big.NewInt(threshold)) >= 0
+}
+
+// dropFutureMessage filters out messages too far ahead in sequence or round
+func (c *Core) dropFutureMessage(view *wbft.View) bool {
+	curr := c.currentView()
+
+	if isFutureSequence(view.Sequence, curr.Sequence) {
+		c.logger.Warn("WBFT: future message too far ahead in sequence, dropped",
+			"msg_seq", view.Sequence.String(),
+			"curr_seq", curr.Sequence.String(),
+		)
+		return true
+	}
+
+	if view.Sequence.Cmp(curr.Sequence) == 0 && view.Round.Cmp(curr.Round) > 0 {
+		if roundDiff, tooFar := isRoundTooFarAhead(view.Round, curr.Round, 10); tooFar {
+			c.logger.Warn("WBFT: future message too far ahead in round, dropped",
+				"msg_round", view.Round.String(),
+				"curr_round", curr.Round.String(),
+				"diff", roundDiff.String(),
+			)
+			return true
+		}
+	}
+
+	return false
+}
+
 // checkMessage checks that a message matches our current WBFT state
 //
 // In particular it ensures that
@@ -54,6 +91,10 @@ var (
 func (c *Core) checkMessage(msgCode uint64, view *wbft.View) error {
 	if view == nil || view.Sequence == nil || view.Round == nil {
 		return errInvalidMessage
+	}
+
+	if c.dropFutureMessage(view) {
+		return errFutureViewTooFar
 	}
 
 	if msgCode == wbfmessage.RoundChangeCode {

--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -58,10 +58,10 @@ func (c *Core) isRoundTooFarAhead(viewRound, currRound *big.Int, threshold int64
 	return roundDiff, roundDiff.Cmp(big.NewInt(threshold)) >= 0
 }
 
-// dropFutureTooFarMessage filters out messages too far ahead in sequence or round
+// isTooFarFutureMessage filters out messages too far ahead in sequence or round
 // This function prevents the node from processing messages that are excessively ahead,
 // which could disrupt the normal flow of the consensus process
-func (c *Core) dropFutureTooFarMessage(view *wbft.View) bool {
+func (c *Core) isTooFarFutureMessage(view *wbft.View) bool {
 	curr := c.currentView()
 
 	if view.Sequence.Cmp(curr.Sequence) > 0 {
@@ -107,7 +107,7 @@ func (c *Core) checkMessage(msgCode uint64, view *wbft.View) error {
 
 	// Drop the message if the view's sequence or round number is too far ahead
 	// This prevents processing of messages that may disrupt consensus due to excessive lead
-	if c.dropFutureTooFarMessage(view) {
+	if c.isTooFarFutureMessage(view) {
 		return errFutureViewTooFar
 	}
 

--- a/consensus/wbft/core/errors.go
+++ b/consensus/wbft/core/errors.go
@@ -45,4 +45,8 @@ var (
 	// errInvalidExtraSealMessage is returned when message is not appropriate to be added to extraSeals
 	errInvalidExtraSealMessage = errors.New("invalid extra seal message")
 	errCurrentIsNil            = errors.New("current is nil")
+
+	// errFutureMessage is returned when the received message has a view
+	// significantly ahead of the current view (in sequence or round).
+	errFutureViewTooFar = errors.New("future view too far ahead: sequence or round difference too large")
 )


### PR DESCRIPTION
**Purpose**
- Add logic to drop messages whose view is ahead of the current view beyond a configured threshold, in order to improve consensus stability.

**Attack Scenario**
- An attacker sends 10,000 ROUND-CHANGE messages with increasing round numbers.
- This leads to backlog overflow and causes consensus to stall.

**Changes**
- Drop messages with a sequence or round number exceeding the configured threshold.

**Expected Effects**
- Prevents consensus disruption due to excessive future messages.
- Avoids backlog overload and memory pressure.