### PR TITLE
fix: fee calculation logic and refactor buyGas with compatibility for WEMIX 3.0 bad blocks

### DIFF
--- a/cmd/evm/testdata/12/readme.md
+++ b/cmd/evm/testdata/12/readme.md
@@ -30,7 +30,7 @@ INFO [03-09|10:43:12.650] Trie dumping complete                    accounts=1 el
     "rejected": [
       {
         "index": 0,
-        "error": "insufficient funds for gas * price + value: address 0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B have 84000000 want 84000032"
+        "error": "insufficient funds for gas * price + value: sender 0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B have 84000000 want 84000032"
       }
     ],
     "currentDifficulty": "0x20000",

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -169,13 +169,13 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					makeTx(key1, 0, common.Address{}, big.NewInt(1000000000000000000), params.TxGas, big.NewInt(875000000), nil),
 				},
-				want: "could not apply tx 0 [0x98c796b470f7fcab40aaef5c965a602b0238e1034cce6fb73823042dd0638d74]: insufficient funds for gas * price + value: address 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 1000018375000000000",
+				want: "could not apply tx 0 [0x98c796b470f7fcab40aaef5c965a602b0238e1034cce6fb73823042dd0638d74]: insufficient funds for gas * price + value: sender 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 1000018375000000000",
 			},
 			{ // ErrInsufficientFunds
 				txs: []*types.Transaction{
 					makeTx(key1, 0, common.Address{}, big.NewInt(0), params.TxGas, big.NewInt(900000000000000000), nil),
 				},
-				want: "could not apply tx 0 [0x4a69690c4b0cd85e64d0d9ea06302455b01e10a83db964d60281739752003440]: insufficient funds for gas * price + value: address 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 18900000000000000000000",
+				want: "could not apply tx 0 [0x4a69690c4b0cd85e64d0d9ea06302455b01e10a83db964d60281739752003440]: insufficient funds for gas * price + value: sender 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 18900000000000000000000",
 			},
 			// ErrGasUintOverflow
 			// One missing 'core' error is ErrGasUintOverflow: "gas uint64 overflow",
@@ -226,13 +226,13 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(1), big.NewInt(50000000000000)),
 				},
-				want: "could not apply tx 0 [0x413603cd096a87f41b1660d3ed3e27d62e1da78eac138961c0a1314ed43bd129]: insufficient funds for gas * price + value: address 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 1050000000000000000",
+				want: "could not apply tx 0 [0x413603cd096a87f41b1660d3ed3e27d62e1da78eac138961c0a1314ed43bd129]: insufficient funds for gas * price + value: sender 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 1050000000000000000",
 			},
 			{ // Another ErrInsufficientFunds, this one to ensure that feecap/tip of max u256 is allowed
 				txs: []*types.Transaction{
 					mkDynamicTx(0, common.Address{}, params.TxGas, bigNumber, bigNumber),
 				},
-				want: "could not apply tx 0 [0xd82a0c2519acfeac9a948258c47e784acd20651d9d80f9a1c67b4137651c3a24]: insufficient funds for gas * price + value: address 0x71562b71999873DB5b286dF957af199Ec94617F7 required balance exceeds 256 bits",
+				want: "could not apply tx 0 [0xd82a0c2519acfeac9a948258c47e784acd20651d9d80f9a1c67b4137651c3a24]: insufficient funds for gas * price + value: sender 0x71562b71999873DB5b286dF957af199Ec94617F7 required balance exceeds 256 bits",
 			},
 			{ // ErrMaxInitCodeSizeExceeded
 				txs: []*types.Transaction{

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -282,7 +282,7 @@ func (st *StateTransition) buyGas() error {
 		total := new(big.Int).Add(feeCheck, valCheck)
 		totalU256, overflow := uint256.FromBig(total)
 		if overflow {
-			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
+			return fmt.Errorf("%w: sender %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
 		}
 		if have := st.state.GetBalance(st.msg.From); have.Cmp(totalU256) < 0 {
 			return fmt.Errorf("%w: sender %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, totalU256)
@@ -294,7 +294,7 @@ func (st *StateTransition) buyGas() error {
 		// Check if feePayer has enough to cover the gas fee
 		feeCheckU256, overflow := uint256.FromBig(feeCheck)
 		if overflow {
-			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, payer.Hex())
+			return fmt.Errorf("%w: feePayer %v required balance exceeds 256 bits", ErrInsufficientFunds, payer.Hex())
 		}
 		if have := st.state.GetBalance(payer); have.Cmp(feeCheckU256) < 0 {
 			return fmt.Errorf("%w: feePayer %v have %v want %v", ErrInsufficientFunds, payer.Hex(), have, feeCheckU256)
@@ -303,7 +303,7 @@ func (st *StateTransition) buyGas() error {
 		// Check if sender has enough to cover the value transfer
 		valCheckU256, overflow := uint256.FromBig(valCheck)
 		if overflow {
-			return fmt.Errorf("%w: address %v required value exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
+			return fmt.Errorf("%w: sender %v required value exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
 		}
 		if have := st.state.GetBalance(st.msg.From); have.Cmp(valCheckU256) < 0 {
 			return fmt.Errorf("%w: sender %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, valCheckU256)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -308,6 +308,10 @@ func (st *StateTransition) buyGas() error {
 		}
 	}
 
+	if err := st.gp.SubGas(st.msg.GasLimit); err != nil {
+		return err
+	}
+
 	st.gasRemaining += st.msg.GasLimit
 
 	st.initialGas = st.msg.GasLimit

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -254,9 +254,11 @@ func (st *StateTransition) buyGas() error {
 	mgval.Mul(mgval, st.msg.GasPrice)
 
 	feeCheck := new(big.Int).Set(mgval)
-	if st.msg.GasFeeCap != nil {
-		feeCheck.SetUint64(st.msg.GasLimit)
-		feeCheck.Mul(feeCheck, st.msg.GasFeeCap)
+	if !st.evm.ChainConfig().CroissantEnabled() || st.evm.ChainConfig().IsCroissant(st.evm.Context.BlockNumber) || !isFeeDelegation {
+		if st.msg.GasFeeCap != nil {
+			feeCheck.SetUint64(st.msg.GasLimit)
+			feeCheck.Mul(feeCheck, st.msg.GasFeeCap)
+		}
 	}
 
 	valCheck := new(big.Int).Set(st.msg.Value)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -247,8 +247,8 @@ func (st *StateTransition) buyGas() error {
 		if st.msg.GasFeeCap != nil {
 			balanceCheck.SetUint64(st.msg.GasLimit)
 			balanceCheck = balanceCheck.Mul(balanceCheck, st.msg.GasFeeCap)
-			balanceCheck.Add(balanceCheck, st.msg.Value)
 		}
+		balanceCheck.Add(balanceCheck, st.msg.Value)
 
 		if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
 			if blobGas := st.blobGasUsed(); blobGas > 0 {
@@ -286,12 +286,11 @@ func (st *StateTransition) buyGas() error {
 		mgval := new(big.Int).SetUint64(st.msg.GasLimit)
 		mgval.Mul(mgval, st.msg.GasPrice)
 		feeCheck := new(big.Int).Set(mgval)
-		valCheck := new(big.Int)
 		if st.msg.GasFeeCap != nil {
 			feeCheck.SetUint64(st.msg.GasLimit)
 			feeCheck = feeCheck.Mul(feeCheck, st.msg.GasFeeCap)
-			valCheck.Set(st.msg.Value)
 		}
+		valCheck := new(big.Int).Set(st.msg.Value)
 
 		if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
 			if blobGas := st.blobGasUsed(); blobGas > 0 {
@@ -314,10 +313,10 @@ func (st *StateTransition) buyGas() error {
 			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
 		}
 		if have, want := st.state.GetBalance(*st.msg.FeePayer), feeCheckU256; have.Cmp(want) < 0 {
-			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.FeePayer.Hex(), have, want)
+			return fmt.Errorf("%w: feePayer %v have %v want %v", ErrInsufficientFunds, st.msg.FeePayer.Hex(), have, want)
 		}
 		if have, want := st.state.GetBalance(st.msg.From), valCheckU256; have.Cmp(want) < 0 {
-			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
+			return fmt.Errorf("%w: sender %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
 		}
 		if err := st.gp.SubGas(st.msg.GasLimit); err != nil {
 			return err

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -316,7 +316,7 @@ func (st *StateTransition) buyGas() error {
 
 	st.initialGas = st.msg.GasLimit
 	mgvalU256, _ := uint256.FromBig(mgval)
-	st.state.SubBalance(st.msg.From, mgvalU256)
+	st.state.SubBalance(payer, mgvalU256)
 	return nil
 }
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -240,95 +240,80 @@ func (st *StateTransition) to() common.Address {
 }
 
 func (st *StateTransition) buyGas() error {
-	if st.msg.FeePayer == nil || *st.msg.FeePayer == st.msg.From {
-		mgval := new(big.Int).SetUint64(st.msg.GasLimit)
-		mgval.Mul(mgval, st.msg.GasPrice)
-		balanceCheck := new(big.Int).Set(mgval)
-		if st.msg.GasFeeCap != nil {
-			balanceCheck.SetUint64(st.msg.GasLimit)
-			balanceCheck = balanceCheck.Mul(balanceCheck, st.msg.GasFeeCap)
-		}
-		balanceCheck.Add(balanceCheck, st.msg.Value)
+	isFeeDelegation := st.msg.FeePayer != nil && *st.msg.FeePayer != st.msg.From
+	if isFeeDelegation && !st.evm.ChainConfig().IsApplepie(st.evm.Context.BlockNumber) {
+		return fmt.Errorf("%w: fee delegation type not supported", ErrTxTypeNotSupported)
+	}
 
-		if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
-			if blobGas := st.blobGasUsed(); blobGas > 0 {
-				// Check that the user has enough funds to cover blobGasUsed * tx.BlobGasFeeCap
-				blobBalanceCheck := new(big.Int).SetUint64(blobGas)
-				blobBalanceCheck.Mul(blobBalanceCheck, st.msg.BlobGasFeeCap)
-				balanceCheck.Add(balanceCheck, blobBalanceCheck)
-				// Pay for blobGasUsed * actual blob fee
-				blobFee := new(big.Int).SetUint64(blobGas)
-				blobFee.Mul(blobFee, st.evm.Context.BlobBaseFee)
-				mgval.Add(mgval, blobFee)
-			}
+	payer := st.msg.From
+	if isFeeDelegation {
+		payer = *st.msg.FeePayer
+	}
+
+	mgval := new(big.Int).SetUint64(st.msg.GasLimit)
+	mgval.Mul(mgval, st.msg.GasPrice)
+
+	feeCheck := new(big.Int).Set(mgval)
+	if st.msg.GasFeeCap != nil {
+		feeCheck.SetUint64(st.msg.GasLimit)
+		feeCheck.Mul(feeCheck, st.msg.GasFeeCap)
+	}
+
+	valCheck := new(big.Int).Set(st.msg.Value)
+
+	if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
+		if blobGas := st.blobGasUsed(); blobGas > 0 {
+			// Check that the user has enough funds to cover blobGasUsed * tx.BlobGasFeeCap
+			blobBalanceCheck := new(big.Int).SetUint64(blobGas)
+			blobBalanceCheck.Mul(blobBalanceCheck, st.msg.BlobGasFeeCap)
+			feeCheck.Add(feeCheck, blobBalanceCheck)
+			// Pay for blobGasUsed * actual blob fee
+			blobFee := new(big.Int).SetUint64(blobGas)
+			blobFee.Mul(blobFee, st.evm.Context.BlobBaseFee)
+			mgval.Add(mgval, blobFee)
 		}
-		balanceCheckU256, overflow := uint256.FromBig(balanceCheck)
+	}
+
+	if !isFeeDelegation {
+		// The sender (`msg.From`) pays both the gas fee and the value.
+		// We must ensure the sender has enough balance to cover (gas fee + value).
+		total := new(big.Int).Add(feeCheck, valCheck)
+		totalU256, overflow := uint256.FromBig(total)
 		if overflow {
 			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
 		}
-		if have, want := st.state.GetBalance(st.msg.From), balanceCheckU256; have.Cmp(want) < 0 {
-			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
+		if have := st.state.GetBalance(st.msg.From); have.Cmp(totalU256) < 0 {
+			return fmt.Errorf("%w: sender %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, totalU256)
 		}
-		if err := st.gp.SubGas(st.msg.GasLimit); err != nil {
-			return err
-		}
-		st.gasRemaining += st.msg.GasLimit
-
-		st.initialGas = st.msg.GasLimit
-		mgvalU256, _ := uint256.FromBig(mgval)
-		st.state.SubBalance(st.msg.From, mgvalU256)
-		return nil
 	} else {
-		if !st.evm.ChainConfig().IsApplepie(st.evm.Context.BlockNumber) {
-			return fmt.Errorf("%w: fee delegation type not supported", ErrTxTypeNotSupported)
-		}
+		// Fee delegation: the feePayer covers the gas fee, the sender covers the value.
+		// We check their balances separately.
 
-		mgval := new(big.Int).SetUint64(st.msg.GasLimit)
-		mgval.Mul(mgval, st.msg.GasPrice)
-		feeCheck := new(big.Int).Set(mgval)
-		if st.msg.GasFeeCap != nil {
-			feeCheck.SetUint64(st.msg.GasLimit)
-			feeCheck = feeCheck.Mul(feeCheck, st.msg.GasFeeCap)
-		}
-		valCheck := new(big.Int).Set(st.msg.Value)
-
-		if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
-			if blobGas := st.blobGasUsed(); blobGas > 0 {
-				// Check that the user has enough funds to cover blobGasUsed * tx.BlobGasFeeCap
-				blobBalanceCheck := new(big.Int).SetUint64(blobGas)
-				blobBalanceCheck.Mul(blobBalanceCheck, st.msg.BlobGasFeeCap)
-				feeCheck.Add(feeCheck, blobBalanceCheck)
-				// Pay for blobGasUsed * actual blob fee
-				blobFee := new(big.Int).SetUint64(blobGas)
-				blobFee.Mul(blobFee, st.evm.Context.BlobBaseFee)
-				mgval.Add(mgval, blobFee)
-			}
-		}
+		// Check if feePayer has enough to cover the gas fee
 		feeCheckU256, overflow := uint256.FromBig(feeCheck)
 		if overflow {
-			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
+			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, payer.Hex())
 		}
+		if have := st.state.GetBalance(payer); have.Cmp(feeCheckU256) < 0 {
+			return fmt.Errorf("%w: feePayer %v have %v want %v", ErrInsufficientFunds, payer.Hex(), have, feeCheckU256)
+		}
+
+		// Check if sender has enough to cover the value transfer
 		valCheckU256, overflow := uint256.FromBig(valCheck)
 		if overflow {
-			return fmt.Errorf("%w: address %v required balance exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
+			return fmt.Errorf("%w: address %v required value exceeds 256 bits", ErrInsufficientFunds, st.msg.From.Hex())
 		}
-		if have, want := st.state.GetBalance(*st.msg.FeePayer), feeCheckU256; have.Cmp(want) < 0 {
-			return fmt.Errorf("%w: feePayer %v have %v want %v", ErrInsufficientFunds, st.msg.FeePayer.Hex(), have, want)
+		if have := st.state.GetBalance(st.msg.From); have.Cmp(valCheckU256) < 0 {
+			return fmt.Errorf("%w: sender %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, valCheckU256)
 		}
-		if have, want := st.state.GetBalance(st.msg.From), valCheckU256; have.Cmp(want) < 0 {
-			return fmt.Errorf("%w: sender %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
-		}
-		if err := st.gp.SubGas(st.msg.GasLimit); err != nil {
-			return err
-		}
-
-		st.gasRemaining += st.msg.GasLimit
-
-		st.initialGas = st.msg.GasLimit
-		mgvalU256, _ := uint256.FromBig(mgval)
-		st.state.SubBalance(*st.msg.FeePayer, mgvalU256)
-		return nil
 	}
+
+	st.gasRemaining += st.msg.GasLimit
+
+	st.initialGas = st.msg.GasLimit
+	mgvalU256, _ := uint256.FromBig(mgval)
+	st.state.SubBalance(st.msg.From, mgvalU256)
+	return nil
 }
 
 func (st *StateTransition) preCheck() error {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -298,7 +298,7 @@ func TestTraceCall(t *testing.T) {
 				Value: (*hexutil.Big)(new(big.Int).Add(big.NewInt(params.Ether), big.NewInt(100))),
 			},
 			config:    &TraceCallConfig{TxIndex: uintPtr(0)},
-			expectErr: fmt.Errorf("tracing failed: insufficient funds for gas * price + value: address %s have 1000000000000000000 want 1000000000000000100", accounts[2].addr),
+			expectErr: fmt.Errorf("tracing failed: insufficient funds for gas * price + value: sender %s have 1000000000000000000 want 1000000000000000100", accounts[2].addr),
 		},
 		// Before the target transaction, should be failed
 		{
@@ -309,7 +309,7 @@ func TestTraceCall(t *testing.T) {
 				Value: (*hexutil.Big)(new(big.Int).Add(big.NewInt(params.Ether), big.NewInt(100))),
 			},
 			config:    &TraceCallConfig{TxIndex: uintPtr(1)},
-			expectErr: fmt.Errorf("tracing failed: insufficient funds for gas * price + value: address %s have 1000000000000000000 want 1000000000000000100", accounts[2].addr),
+			expectErr: fmt.Errorf("tracing failed: insufficient funds for gas * price + value: sender %s have 1000000000000000000 want 1000000000000000100", accounts[2].addr),
 		},
 		// After the target transaction, should be succeed
 		{


### PR DESCRIPTION
The issue was first brought to attention in this issue: [wemixarchive/wbft#129](https://github.com/wemixarchive/wbft/issues/129)

The following two issues were fixed, fully resolving the original problem:

1. Refactored buyGas() and included the fix from PR‑29762 for EIP‑1559 balance check
- Integrated the logic from [Ethereum PR‑29762](https://github.com/ethereum/go-ethereum/pull/29762) to ensure that msg.Value is always included in the balance check when processing EIP‑1559 transactions.
- Refactored the buyGas() function to clarify fee delegation logic and reduce code duplication.

2. Fixed incorrect fee calculation logic for feePayer transactions in WEMIX 3.0
- Addressed the issue where GasFeeCap was ignored and GasPrice was incorrectly used for fee calculation in legacy WEMIX 3.0 transactions.
- For blocks before the Croissant hard fork, the legacy WEMIX 3.0 fee calculation logic (despite being incorrect) is retained to ensure compatibility with historical bad blocks.


