### PR TITLE
feat: apply transition to proposer policy

### DIFF
--- a/consensus/wbft/backend/backend.go
+++ b/consensus/wbft/backend/backend.go
@@ -319,7 +319,7 @@ func (sb *Backend) GetProposer(number uint64) common.Address {
 func (sb *Backend) Validators(proposal wbft.Proposal) wbft.ValidatorSet {
 	valSet, err := sb.Engine().GetValidators(sb.chain, new(big.Int).Add(proposal.Number(), common.Big1), proposal.Hash(), nil)
 	if err != nil {
-		return validator.NewSet(nil, nil, sb.config.ProposerPolicy)
+		return validator.NewSet(nil, nil, sb.config.GetConfig(proposal.Number()).ProposerPolicy)
 	}
 	return valSet
 }

--- a/consensus/wbft/engine/engine.go
+++ b/consensus/wbft/engine/engine.go
@@ -714,7 +714,7 @@ func (e *Engine) buildEpochInfo(chain consensus.ChainHeaderReader, header *types
 	}
 
 	// Accumulate proposer counts being selected within epoch.
-	valSet := validator.NewSet(validators, latestEpochInfo.BLSPublicKeys, e.cfg.ProposerPolicy)
+	valSet := validator.NewSet(validators, latestEpochInfo.BLSPublicKeys, e.cfg.GetConfig(header.Number).ProposerPolicy)
 	for i := len(proposers) - 1; i >= 0; i-- {
 		proposer := proposers[i]
 		for round := 0; ; round++ {
@@ -961,7 +961,7 @@ func (e *Engine) GetValidators(chain consensus.ChainHeaderReader, blockNumber *b
 		return nil, err
 	}
 
-	vs := validator.NewSet(epochInfo.GetValidators(), epochInfo.BLSPublicKeys, e.cfg.ProposerPolicy)
+	vs := validator.NewSet(epochInfo.GetValidators(), epochInfo.BLSPublicKeys, e.cfg.GetConfig(blockNumber).ProposerPolicy)
 	return vs, nil
 }
 


### PR DESCRIPTION
The transition for `ProposerPolicy` from `WbftConfig` was not being applied  in logic because it was not being called via `GetConfig()`. 