### PR TITLE
feat: increase gasCeil from 30M to 105M

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -61,7 +61,7 @@ type Config struct {
 
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
-	GasCeil:  30000000,
+	GasCeil:  105000000,
 	GasPrice: big.NewInt(params.GWei),
 
 	// The default recommit time is chosen as two seconds since


### PR DESCRIPTION
**Overview**
In the current WEMIX 4.0(WBFT), the default value of _gasCeil_ is set to 30,000,000, and the block Gas Limit is gradually adjusted toward the configured gasCeil value according to the CalcGasLimit() logic.
Therefore, if gasCeil is not changed via CLI or config, the block Gas Limit will converge to the default value of 30,000,000.

**Background**
- In WEMIX 3.0, the Gas Limit is fixed at 105,000,000.
- In WEMIX 4.0(WBFT), gasCeil serves as the target value for Gas Limit changes, and from the moment block production starts, the gasCeil value directly affects the actual Gas Limit.
- While the initial Gas Limit can be set in genesis.json, after the fork is applied, the gasCeil value takes precedence in controlling Gas Limit changes.
- Therefore, to maintain the same Gas Limit (105,000,000) as WEMIX 3.0, gasCeil in WEMIX 4.0 should also be set to the same value.

**Changes**
- Increase the default value of gasCeil from 30,000,000 to 105,000,000.
- Ensure that in WEMIX 4.0, the block Gas Limit is adjusted toward the target value of 105,000,000.

**Expected Effects**
- Apply the same Gas Limit (105,000,000) used in WEMIX 3.0 to the WEMIX 4.0 (WBFT) environment.