### PR TITLE
fix: do commit for pending block in case of non-miner

### DIFF
--- a/consensus/wbft/backend/engine.go
+++ b/consensus/wbft/backend/engine.go
@@ -152,18 +152,13 @@ func (sb *Backend) timeForNextWork() uint64 {
 // Prepare initializes the consensus fields of a block header according to the
 // rules of a particular engine. The changes are executed inline.
 func (sb *Backend) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {
-	valSet, err := sb.Engine().GetValidators(chain, header.Number, header.ParentHash, nil)
-	if err != nil {
-		return err
-	}
-
 	if sb.simApplier != nil {
 		sb.simApplier.Apply(chain.Config(), sb.config, header.Number)
 	}
 
 	extraPreparedSeal, extraCommittedSeal := sb.processExtraSeals()
 
-	err = sb.Engine().Prepare(chain, header, valSet, extraPreparedSeal, extraCommittedSeal)
+	err := sb.Engine().Prepare(chain, header, extraPreparedSeal, extraCommittedSeal)
 	if err != nil {
 		return err
 	}
@@ -227,7 +222,6 @@ func (sb *Backend) processExtraSeals() ([]wbft.SealData, []wbft.SealData) {
 	sb.coreMu.RLock()
 	defer sb.coreMu.RUnlock()
 	if sb.core == nil {
-		sb.logger.Warn("WBFT: fail to process extra seals due to nil core")
 		return nil, nil
 	} else {
 		return sb.core.ProcessExtraSeal(sb.currentBlock(), sb.core.PriorRound(), sb.core.PriorValidators())

--- a/consensus/wbft/engine/engine.go
+++ b/consensus/wbft/engine/engine.go
@@ -447,11 +447,7 @@ func (e *Engine) PeriodToNextBlock(blockNumber *big.Int) uint64 {
 	return e.cfg.GetConfig(blockNumber).BlockPeriod
 }
 
-func (e *Engine) Prepare(chain consensus.ChainHeaderReader, header *types.Header, validators wbft.ValidatorSet, extraPreparedSeal, extraCommittedSeal []wbft.SealData) error {
-	if _, v := validators.GetByAddress(e.Address()); v == nil {
-		return wbftcommon.ErrUnauthorized
-	}
-
+func (e *Engine) Prepare(chain consensus.ChainHeaderReader, header *types.Header, extraPreparedSeal, extraCommittedSeal []wbft.SealData) error {
 	header.Coinbase = e.Address()
 	header.Nonce = wbftcommon.EmptyBlockNonce
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -21,7 +21,6 @@ package miner
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/consensus/wbft"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -32,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/ethereum/go-ethereum/consensus/wbft"
 	wbftBackend "github.com/ethereum/go-ethereum/consensus/wbft/backend"
 	"github.com/ethereum/go-ethereum/consensus/wemix"
 	"github.com/ethereum/go-ethereum/core"

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -21,6 +21,7 @@ package miner
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/consensus/wbft"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -616,8 +617,13 @@ func (w *worker) newWorkLoopWBFT() {
 				panic(fmt.Errorf("invalid engine"))
 			}
 
-			handler.NewChainHead()
+			err := handler.NewChainHead()
 			clearPending(head.Block.NumberU64())
+			if errors.Is(err, wbft.ErrStoppedEngine) {
+				// If WBFT engine is running, we don't need to commit new work here because
+				// it will triggered by readyToCommitCh
+				commit(commitInterruptNewHead)
+			}
 
 		case round := <-w.readyToCommitCh:
 			if round.Uint64() == 0 {


### PR DESCRIPTION
We can't get 'pending' block from an en node.
```
> eth.getBlockByNumber('pending')
Error: pending block is not available
	at web3.js:6367:9(39)
	at send (web3.js:5101:62(29))
	at <eval>:1:21(3)
```

This is because worker does not `commitNewWork` at meeting new chain head if node is not a miner.

PR does fix this.