### PR TITLE
fix: correct round change message quorum validation logic

### DIFF
--- a/consensus/wbft/core/justification.go
+++ b/consensus/wbft/core/justification.go
@@ -90,15 +90,14 @@ func hasQuorumOfRoundChangeMessagesForNil(roundChangeMessages []*wbfmessage.Sign
 // and has `quorumSize` messages with prepared round equal to nil or equal or lower than `preparedRound`.
 func hasQuorumOfRoundChangeMessagesForPreparedRoundAndBlock(roundChangeMessages []*wbfmessage.SignedRoundChangePayload, preparedRound *big.Int, preparedBlock wbft.Proposal, quorumSize int) error {
 	lowerOrEqualRoundCount := 0
-	hasMatchingMessage := false
+
 	for _, m := range roundChangeMessages {
 		log.Trace("WBFT: hasQuorumOfRoundChangeMessagesForPreparedRoundAndBlock", "rc", m)
 		if m.PreparedRound == nil || m.PreparedRound.Cmp(preparedRound) <= 0 {
-			lowerOrEqualRoundCount++
 			if m.PreparedRound != nil && m.PreparedRound.Cmp(preparedRound) == 0 && m.PreparedDigest == preparedBlock.Hash() {
-				hasMatchingMessage = true
+				lowerOrEqualRoundCount++
 			}
-			if lowerOrEqualRoundCount >= quorumSize && hasMatchingMessage {
+			if lowerOrEqualRoundCount >= quorumSize {
 				return nil
 			}
 		}


### PR DESCRIPTION
## Description
  This PR fixes a critical bug in the round change message validation logic within the WBFT consensus mechanism.

  ## Problem
  The previous implementation had a flawed counting mechanism in `hasQuorumOfRoundChangeMessagesForPreparedRoundAndBlock()` function:

  - **Bug**: The `lowerOrEqualRoundCount` counter was incremented for ALL messages with `PreparedRound <= preparedRound`, regardless of whether their `PreparedDigest`
  matched the `preparedBlock` hash
  - **Impact**: This allowed the consensus to proceed without actually having a quorum of round change messages supporting the same prepared block, potentially compromising
   consensus safety

  ## Solution
  Modified the counting logic to only increment `lowerOrEqualRoundCount` when BOTH conditions are satisfied:
  1. `PreparedRound` equals the target `preparedRound`
  2. `PreparedDigest` matches the `preparedBlock` hash

  ## Changes Made
  - Removed the separate `hasMatchingMessage` boolean flag (no longer needed)
  - Moved the `lowerOrEqualRoundCount++` increment inside the condition that checks for matching round and digest
  - Simplified the quorum check to only verify the count

  ## Testing
  - Verified that round change messages are now correctly counted only when they support the same prepared block
  - Ensures proper quorum is achieved before proceeding with consensus

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)