### PR TITLE
feat: epoch info should only be in epoch block

### DIFF
--- a/consensus/wbft/common/errors.go
+++ b/consensus/wbft/common/errors.go
@@ -141,4 +141,6 @@ var (
 	ErrInvalidSpecificCall = errors.New("invalid method name for engine specific function")
 
 	ErrIsNotWBFTBlock = errors.New("block is not a wbft block")
+
+	ErrEpochInfoIsNotNil = errors.New("epoch info should be nil for non-epoch block")
 )

--- a/consensus/wbft/engine/engine.go
+++ b/consensus/wbft/engine/engine.go
@@ -893,6 +893,13 @@ func (e *Engine) processFinalize(chain consensus.ChainHeaderReader, header *type
 		if err = epochHandler(e, chain, header, state); err != nil {
 			return err
 		}
+	} else {
+		extra, err := types.ExtractWBFTExtra(header)
+		if err != nil {
+			return err
+		} else if extra.EpochInfo != nil {
+			return wbftcommon.ErrEpochInfoIsNotNil
+		}
 	}
 
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))


### PR DESCRIPTION
Related Issue : https://github.com/wemixarchive/go-wemix-wbft/issues/115

This pr is to prevent malicious validators to inject epoch info to non-epoch block. 
Validators should cause bad block error if non-epoch block contains epoch info.