### PR TITLE
fix: must use previous validator set to handle prevSeals

### DIFF
--- a/consensus/wbft/backend/api.go
+++ b/consensus/wbft/backend/api.go
@@ -230,6 +230,7 @@ func sealForJSON(seal *types.WBFTAggregatedSeal, valSet []common.Address) map[st
 	}
 
 	sealerIndxs := seal.Sealers.GetSealers()
+
 	sealers := make([]string, 0, len(sealerIndxs))
 
 	for _, idx := range sealerIndxs {
@@ -308,13 +309,11 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 	}
 
 	header := api.chain.GetHeaderByNumber(uint64(number))
-
 	if header == nil {
 		return nil, fmt.Errorf("block %d not found", bNumber)
 	}
 
 	extra, err := types.ExtractWBFTExtra(header)
-
 	if err != nil {
 		return nil, err
 	}
@@ -324,16 +323,32 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 		return nil, err
 	}
 
+	var prevSeals map[string]interface{}
+	if number > 0 {
+		prevBlockNumber := rpc.BlockNumber(number.Int64() - 1)
+		prevVals, err := api.GetValidators(&prevBlockNumber)
+		if err != nil {
+			return nil, err
+		}
+		prevSeals = map[string]interface{}{
+			"prevPreparedSeal":  sealForJSON(extra.PrevPreparedSeal, prevVals),
+			"prevCommittedSeal": sealForJSON(extra.PrevCommittedSeal, prevVals),
+		}
+	}
+
 	result := map[string]interface{}{
-		"vanityData":        DecodeVanityData(extra.VanityData),
-		"randaoReveal":      "0x" + hex.EncodeToString(extra.RandaoReveal),
-		"prevRound":         fmt.Sprintf("0x%x", extra.PrevRound),
-		"prevPreparedSeal":  sealForJSON(extra.PrevPreparedSeal, validators),
-		"prevCommittedSeal": sealForJSON(extra.PrevCommittedSeal, validators),
-		"round":             fmt.Sprintf("0x%x", extra.Round),
-		"preparedSeal":      sealForJSON(extra.PreparedSeal, validators),
-		"committedSeal":     sealForJSON(extra.CommittedSeal, validators),
-		"epochInfo":         epochForJSON(extra.EpochInfo),
+		"vanityData":    DecodeVanityData(extra.VanityData),
+		"randaoReveal":  "0x" + hex.EncodeToString(extra.RandaoReveal),
+		"prevRound":     fmt.Sprintf("0x%x", extra.PrevRound),
+		"round":         fmt.Sprintf("0x%x", extra.Round),
+		"preparedSeal":  sealForJSON(extra.PreparedSeal, validators),
+		"committedSeal": sealForJSON(extra.CommittedSeal, validators),
+		"epochInfo":     epochForJSON(extra.EpochInfo),
+	}
+
+	if number > 0 {
+		result["prevPreparedSeal"] = prevSeals["prevPreparedSeal"]
+		result["prevCommittedSeal"] = prevSeals["prevCommittedSeal"]
 	}
 
 	return result, nil

--- a/consensus/wbft/backend/api.go
+++ b/consensus/wbft/backend/api.go
@@ -318,37 +318,21 @@ func (api *API) GetWbftExtraInfo(number rpc.BlockNumber) (map[string]interface{}
 		return nil, err
 	}
 
-	validators, err := api.GetValidators(&number)
+	curValidators, prevValidators, err := api.backend.GetValidatorsForVerifying(api.chain, header, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var prevSeals map[string]interface{}
-	if number > 0 {
-		prevBlockNumber := rpc.BlockNumber(number.Int64() - 1)
-		prevVals, err := api.GetValidators(&prevBlockNumber)
-		if err != nil {
-			return nil, err
-		}
-		prevSeals = map[string]interface{}{
-			"prevPreparedSeal":  sealForJSON(extra.PrevPreparedSeal, prevVals),
-			"prevCommittedSeal": sealForJSON(extra.PrevCommittedSeal, prevVals),
-		}
-	}
-
 	result := map[string]interface{}{
-		"vanityData":    DecodeVanityData(extra.VanityData),
-		"randaoReveal":  "0x" + hex.EncodeToString(extra.RandaoReveal),
-		"prevRound":     fmt.Sprintf("0x%x", extra.PrevRound),
-		"round":         fmt.Sprintf("0x%x", extra.Round),
-		"preparedSeal":  sealForJSON(extra.PreparedSeal, validators),
-		"committedSeal": sealForJSON(extra.CommittedSeal, validators),
-		"epochInfo":     epochForJSON(extra.EpochInfo),
-	}
-
-	if number > 0 {
-		result["prevPreparedSeal"] = prevSeals["prevPreparedSeal"]
-		result["prevCommittedSeal"] = prevSeals["prevCommittedSeal"]
+		"vanityData":        DecodeVanityData(extra.VanityData),
+		"randaoReveal":      "0x" + hex.EncodeToString(extra.RandaoReveal),
+		"prevRound":         fmt.Sprintf("0x%x", extra.PrevRound),
+		"prevPreparedSeal":  sealForJSON(extra.PrevPreparedSeal, prevValidators.AddressList()),
+		"prevCommittedSeal": sealForJSON(extra.PrevCommittedSeal, prevValidators.AddressList()),
+		"round":             fmt.Sprintf("0x%x", extra.Round),
+		"preparedSeal":      sealForJSON(extra.PreparedSeal, curValidators.AddressList()),
+		"committedSeal":     sealForJSON(extra.CommittedSeal, curValidators.AddressList()),
+		"epochInfo":         epochForJSON(extra.EpochInfo),
 	}
 
 	return result, nil


### PR DESCRIPTION
## Overview

The feature introduced in the previously merged PR #143 was reverted.

This PR restores the reverted functionality, fixes the original bug, and includes additional improvements.

## Changes
Changed to the suggested code

## 🔗 Related Issues

- Closes #143 (Reverts this PR)
