### PR TITLE
fix: verify prepared block of round change message

### DIFF
--- a/consensus/wbft/core/roundchange.go
+++ b/consensus/wbft/core/roundchange.go
@@ -119,6 +119,13 @@ func (c *Core) handleRoundChangeMsg(roundChange *wbfmessage.RoundChange) error {
 		var pr *big.Int = nil
 		var pb *types.Block = nil
 		if roundChange.PreparedRound != nil && roundChange.PreparedBlock != nil && roundChange.Justification != nil && len(roundChange.Justification) > 0 {
+			// We should check the prepared block hash and sequence number
+			if roundChange.PreparedBlock.Number().Cmp(c.currentView().Sequence) != 0 {
+				return errors.New("WBFT: prepared block number does not match current sequence number in ROUND-CHANGE message")
+			}
+			if roundChange.PreparedBlock.Hash() != roundChange.PreparedDigest {
+				return errors.New("WBFT: prepared block hash does not match prepared digest in ROUND-CHANGE message")
+			}
 			prepareMessages = roundChange.Justification
 			pr = roundChange.PreparedRound
 			pb = roundChange.PreparedBlock

--- a/consensus/wbft/core/roundchange.go
+++ b/consensus/wbft/core/roundchange.go
@@ -22,6 +22,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"sort"
 	"sync"
@@ -121,10 +122,22 @@ func (c *Core) handleRoundChangeMsg(roundChange *wbfmessage.RoundChange) error {
 		if roundChange.PreparedRound != nil && roundChange.PreparedBlock != nil && roundChange.Justification != nil && len(roundChange.Justification) > 0 {
 			// We should check the prepared block hash and sequence number
 			if roundChange.PreparedBlock.Number().Cmp(c.currentView().Sequence) != 0 {
-				return errors.New("WBFT: prepared block number does not match current sequence number in ROUND-CHANGE message")
+				err := fmt.Errorf(
+					"prepared block number %v does not match current sequence %v",
+					roundChange.PreparedBlock.Number().Uint64(),
+					c.currentView().Sequence.Uint64(),
+				)
+				logger.Warn("WBFT: round-change validation failed", "err", err)
+				return err
 			}
 			if roundChange.PreparedBlock.Hash() != roundChange.PreparedDigest {
-				return errors.New("WBFT: prepared block hash does not match prepared digest in ROUND-CHANGE message")
+				err := fmt.Errorf(
+					"prepared block hash %s does not match prepared digest %s in ROUND-CHANGE message",
+					roundChange.PreparedBlock.Hash().Hex(),
+					roundChange.PreparedDigest.Hex(),
+				)
+				logger.Warn("WBFT: round-change validation failed", "err", err)
+				return err
 			}
 			prepareMessages = roundChange.Justification
 			pr = roundChange.PreparedRound


### PR DESCRIPTION
This fixes the problem that byzantine validator can broadcast a round change message having invalid prepared block(old sequence block).

If it can be, the receiving validator gets penalty when he becomes a proposer.

related with #142 