### PR TITLE
fix: skip epoch block creation for ex-validator

### DIFF
--- a/consensus/wbft/engine/engine.go
+++ b/consensus/wbft/engine/engine.go
@@ -1180,6 +1180,12 @@ func (e *Engine) calculateRewards(chain consensus.ChainHeaderReader, header *typ
 }
 
 func writeEpoch(e *Engine, chain consensus.ChainHeaderReader, header *types.Header, state govwbft.StateReader) error {
+	if valSet, err := e.GetValidators(chain, header.Number, header.ParentHash, nil); err != nil {
+		return err
+	} else if idx, _ := valSet.GetByAddress(e.Address()); idx < 0 {
+		return nil
+	}
+
 	newEpoch, err := e.buildEpochInfo(chain, header, state)
 	if err != nil {
 		return err


### PR DESCRIPTION
- Fix errors caused by ex-validator nodes attempting epoch block creation
- In `writeEpoch`, skip epoch block creation for non-validator nodes to ensure pending block updates remain consistent.