### PR TITLE
fix: missing extraSeals on round change

### DIFF
--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -229,10 +229,10 @@ func (c *Core) startNewRound(round *big.Int) {
 			Round:    new(big.Int),
 		}
 		nextValSet = c.backend.Validators(lastProposal)
-	}
 
-	// Add extra seal that contributed to consensus
-	c.addEffectiveSealToExtraSeal()
+		// Add extra seal that contributed to consensus
+		c.addEffectiveSealToExtraSeal()
+	}
 
 	// New snapshot for new round
 	c.updateRoundState(nextValSet, newView, roundChange)


### PR DESCRIPTION
- Fixed an issue where `preparedSeals` for block `n` overwrote the `preparedSeals (extraSeals)` for block `n-1` during a round change in prepare.
