### PR TITLE
fix: adjust default priority fee to 100Gwei

### DIFF
--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -84,7 +84,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block) {
 	generate := func(i int, g *core.BlockGen) {
 		g.OffsetTime(5)
 		g.SetExtra([]byte("test"))
-		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*2), nil), types.LatestSigner(&config), testKey)
+		tx, _ := types.SignTx(types.NewTransaction(testNonce, common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"), big.NewInt(1), params.TxGas, big.NewInt(params.InitialBaseFee*200), nil), types.LatestSigner(&config), testKey)
 		g.AddTx(tx)
 		testNonce++
 	}
@@ -606,7 +606,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 			Nonce:    statedb.GetNonce(testAddr),
 			Value:    new(big.Int),
 			Gas:      1000000,
-			GasPrice: big.NewInt(2 * params.InitialBaseFee),
+			GasPrice: big.NewInt(200 * params.InitialBaseFee),
 			Data:     logCode,
 		})
 		ethservice.TxPool().Add([]*types.Transaction{tx}, false, true)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -60,10 +60,20 @@ type Config struct {
 	SimulatedEnabled bool `toml:",omitempty"`
 }
 
+const (
+	// DefaultGasPriceGWei is the default gas price for Wemix 3.0 compatibility.
+	DefaultGasPriceGWei = 100
+)
+
+// DefaultGasPrice Pre-computed gas price values
+var (
+	DefaultGasPrice = big.NewInt(DefaultGasPriceGWei * params.GWei)
+)
+
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
 	GasCeil:  105000000,
-	GasPrice: big.NewInt(100 * params.GWei), // 100 GWei for compatibility with Wemix 3.0
+	GasPrice: DefaultGasPrice, // Use pre-computed constant for clarity and maintenance
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -63,7 +63,7 @@ type Config struct {
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
 	GasCeil:  105000000,
-	GasPrice: big.NewInt(params.GWei),
+	GasPrice: big.NewInt(100 * params.GWei), // 100 GWei for compatibility with Wemix 3.0
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)


### PR DESCRIPTION
Modify default priority fee per gas from 1 Gwei to 100 Gwei for compatibility with Wemix3.0.