### PR TITLE
fix: align F() calculation with BFT formula (n-1)/3

### DIFF
--- a/consensus/wbft/backend/engine_test.go
+++ b/consensus/wbft/backend/engine_test.go
@@ -808,14 +808,22 @@ func nodeSendCommitMsg(wbftEngine *Backend, node otherNode, sequence, round *big
 }
 
 func TestAddingExtraSeals(t *testing.T) {
-	// assume 3 nodes,
-	// one is myself, two is normal node, three is slow node that sends extraSeals
-	expectedAdditionalPreparedSealCnt := 3
-	expectedAdditionalCommittedSealCnt := 3
+	// Assume 4 validator nodes total:
+	// - nodes[0]: engine (proposer, myself)
+	// - nodes[1]: normalNode1 (normal responding node)
+	// - nodes[2]: normalNode2 (normal responding node)
+	// - nodes[3]: slowNode (late responding node that sends extraSeals)
+	// With n=4, QuorumSize=3 (minimum for consensus)
+	// However, all 4 nodes eventually send messages, so we expect 4 seals total
+	// - 3 seals contribute to consensus (proposer + normalNode1 + normalNode2
+	// - 1 extra seal from slowNode (arrives late after consensus completes
+	expectedAdditionalPreparedSealCnt := 4  // All 4 nodes send PREPARE 3 for consensus and extra 1
+	expectedAdditionalCommittedSealCnt := 4 // All 4 nodes send COMMIT 3 for consensus and extra 1
 
-	chain, engine, nodes := newBlockChain(3)
-	normalNode := nodes[1]
-	slowNode := nodes[2]
+	chain, engine, nodes := newBlockChain(4)
+	normalNode1 := nodes[1]
+	normalNode2 := nodes[2]
+	slowNode := nodes[3]
 
 	parentBlock := chain.Genesis()
 	eventSub := engine.EventMux().Subscribe(wbft.RequestEvent{})
@@ -854,17 +862,23 @@ func TestAddingExtraSeals(t *testing.T) {
 
 			switch consensusState {
 			case wbftcore.StatePreprepared:
-				if err := nodeSendPrepareMsg(engine, normalNode, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
-					t.Errorf("normal node failed to send prepare msg. err :  %v", err)
+				if err := nodeSendPrepareMsg(engine, normalNode1, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
+					t.Errorf("normalNode1 failed to send prepare msg. err :  %v", err)
+				}
+				if err := nodeSendPrepareMsg(engine, normalNode2, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
+					t.Errorf("normalNode2 failed to send prepare msg. err :  %v", err)
 				}
 				executed[consensusState] = true
 			case wbftcore.StatePrepared:
 				// valid extra seal msg
 				if err := nodeSendPrepareMsg(engine, slowNode, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
-					t.Errorf("slow node failed to send prepare msg. err :  %v", err)
+					t.Errorf("slow node failed to send commit msg. err :  %v", err)
 				}
-				if err := nodeSendCommitMsg(engine, normalNode, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
-					t.Errorf("normal node failed to send commit msg. err :  %v", err)
+				if err := nodeSendCommitMsg(engine, normalNode1, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
+					t.Errorf("normalNode1 failed to send commit msg. err :  %v", err)
+				}
+				if err := nodeSendCommitMsg(engine, normalNode2, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
+					t.Errorf("normalNode2 failed to send commit msg. err :  %v", err)
 				}
 				executed[consensusState] = true
 			case wbftcore.StateCommitted:
@@ -875,8 +889,11 @@ func TestAddingExtraSeals(t *testing.T) {
 				executed[consensusState] = true
 			case wbftcore.StateAcceptRequest:
 				// valid extra seal msg
-				if err := nodeSendCommitMsg(engine, normalNode, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
-					t.Errorf("slow node failed to send prepare msg. err :  %v", err)
+				if err := nodeSendCommitMsg(engine, normalNode1, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
+					t.Errorf("normalNode1 failed to send prepare msg. err :  %v", err)
+				}
+				if err := nodeSendCommitMsg(engine, normalNode2, proposedBlock.Number(), big.NewInt(0), proposedBlock); err != nil {
+					t.Errorf("normalNode2 failed to send prepare msg. err :  %v", err)
 				}
 				// invalid extra seal msg - wrong sequence
 				if err := nodeSendPrepareMsg(engine, slowNode, new(big.Int).Add(proposedBlock.Number(), common.Big1), big.NewInt(1), proposedBlock); err != nil {

--- a/consensus/wbft/validator/default.go
+++ b/consensus/wbft/validator/default.go
@@ -219,7 +219,7 @@ func (valSet *defaultSet) Copy() wbft.ValidatorSet {
 	return NewSetByValidators(validators, valSet.policy)
 }
 
-func (valSet *defaultSet) F() float64 { return float64(valSet.Size()) / 3 }
+func (valSet *defaultSet) F() float64 { return float64(valSet.Size()-1) / 3 }
 
 func (valSet *defaultSet) Policy() wbft.ProposerPolicy { return *valSet.policy }
 


### PR DESCRIPTION
## 📝 Summary
The existing F() function calculated the number of permissible faulty nodes in the BFT consensus algorithm as n/3. This deviated from the standard BFT formula, $F = \lfloor \frac{n-1}{3} \rfloor$ and could potentially introduce errors when the total number of nodes (n) is a multiple of 3, threatening the network's safety.

This PR corrects the calculation to align with the standard BFT formula, ensuring the correctness and stability of the consensus process.

## ✨ Changes
```
// Before: F() was effectively calculated as n/3.

// After: The F() function is updated to conform to the standard BFT formula.
func (valSet *defaultSet) F() float64 {
    // Note: In Go, integer division truncates the decimal part,
    // so (valSet.Size()-1) / 3 is equivalent to floor((n-1)/3).
    return float64(valSet.Size()-1) / 3
}

// QuorumSize() now automatically calculates the correct value as it depends on F().
func (valSet *defaultSet) QuorumSize() int {
    return int(math.Ceil(float64(valSet.Size()) - valSet.F()))
}
```
## 📚 Background & Rationale
A core safety property of the Byzantine Fault Tolerance (BFT) consensus algorithm is that the intersection of any two quorums must be greater than the maximum number of faulty nodes (F). This can be expressed mathematically as:

$Q_1 \cap Q_2 > F$

To guarantee this, the condition $2Q - N > F$ must always hold, where N is the total number of nodes and Q is the quorum size.
To guarantee this, the condition 2Q−N>F must always hold, where N is the total number of nodes and Q is the quorum size.

The previous logic (F = n/3) violated this condition when N was a multiple of 3 (e.g., N=3k). This created a risk where two different blocks could be concurrently signed by a quorum of nodes, potentially causing a network fork.

Mathematical Proof
The parameters according to the corrected formula are as follows:

Total Nodes: $N$

Maximum Faulty Nodes: $F = \lfloor \frac{N-1}{3} \rfloor$

Quorum Size: $Q = \lceil \frac{2N+1}{3} \rceil$

We can now prove that the safety condition ($2Q - N > F$) is met for all possible values of N.

---
Case 1: $N = 3k+1$ (where k ≥ 0 is an integer)
- $F = \lfloor \frac{(3k+1)-1}{3} \rfloor = \lfloor \frac{3k}{3} \rfloor = k$
- $Q = \lceil \frac{2(3k+1)+1}{3} \rceil = \lceil \frac{6k+3}{3} \rceil = 2k+1$
- Verification: $2(2k+1) - (3k+1) = 4k+2 - 3k-1 = k+1 > k = F$

Result: Safety condition is satisfied. ✅

Case 2: $N = 3k+2$ (where k ≥ 0 is an integer)
- $F = \lfloor \frac{(3k+2)-1}{3} \rfloor = \lfloor \frac{3k+1}{3} \rfloor = k$
- $Q = \lceil \frac{2(3k+2)+1}{3} \rceil = \lceil \frac{6k+5}{3} \rceil = \lceil 2k + \frac{5}{3} \rceil = 2k+2$
- Verification: $2(2k+2) - (3k+2) = 4k+4 - 3k-2 = k+2 > k = F$

Result: Safety condition is satisfied. ✅

Case 3: $N = 3k$ (where k ≥ 1 is an integer)
- $F = \lfloor \frac{3k-1}{3} \rfloor = \lfloor k - \frac{1}{3} \rfloor = k-1$
- $Q = \lceil \frac{2(3k)+1}{3} \rceil = \lceil \frac{6k+1}{3} \rceil = \lceil 2k + \frac{1}{3} \rceil = 2k+1$
- Verification: $2(2k+1) - 3k = 4k+2 - 3k = k+1 > k-1 = F$

Result: Safety condition is satisfied. ✅

---
As demonstrated by the proof, correcting the F() calculation ensures the safety of the BFT consensus algorithm for any number of nodes, thereby strengthening the overall network stability.

