### PR TITLE
fix: update pool BaseFee calculation to use eip1599 after Croissant fork

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/wpoa"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -1301,7 +1302,12 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 		pool.demoteUnexecutables()
 		if reset.newHead != nil {
 			if pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
-				pendingBaseFee := wpoa.CalcBaseFee(pool.chainconfig, reset.newHead)
+				var pendingBaseFee *big.Int
+				if pool.chainconfig.IsCroissant(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
+					pendingBaseFee = eip1559.CalcBaseFee(pool.chainconfig, reset.newHead)
+				} else {
+					pendingBaseFee = wpoa.CalcBaseFee(pool.chainconfig, reset.newHead)
+				}
 				pool.priced.SetBaseFee(pendingBaseFee)
 			} else {
 				pool.priced.Reheap()


### PR DESCRIPTION
**Description**
This PR updates the legacypool BaseFee calculation logic to properly handle the Croissant hardfork transition.
After the Croissant fork, the chain adopts the EIP-1559 style base fee mechanism, so pool should use eip1559.CalcBaseFee instead of wpoa.CalcBaseFee.

**Changes**
- Added Croissant fork condition check to BaseFee calculation in legacypool
- Applied eip1559.CalcBaseFee after Croissant fork activation
- Retained wpoa.CalcBaseFee logic for pre-Croissant blocks

## Related Issue
Close #154 