### PR TITLE
fix: no skipping log

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1131,7 +1131,6 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 
 	if w.chainConfig.CroissantBlock != nil && !w.chainConfig.IsCroissant(header.Number) {
 		// If we are not in the Croissant phase, we don't prepare a block
-		log.Info("Skipping block preparation before Croissant hard fork", "number", header.Number, "fork", w.chainConfig.CroissantBlock)
 		return nil, errSkipMiningBeforeCroissant
 	}
 	// Run the consensus preparation with the default or customized consensus engine.


### PR DESCRIPTION
With current version, a full node writes log before croissant hard fork like this.

```
INFO [10-27|17:33:54.293] Imported new chain segment               number=45,195,697 hash=ee6ebc..77b64e blocks=1  txs=0 mgas=0.000 elapsed=8.944ms   mgasps=0.000 snapdiffs=311.68KiB triedirty=947.12KiB
INFO [10-27|17:33:54.293] Skipping block preparation before Croissant hard fork number=45,195,698 fork=46,392,500
INFO [10-27|17:33:55.306] Imported new chain segment               number=45,195,698 hash=373164..4d6772 blocks=1  txs=0 mgas=0.000 elapsed=15.913ms  mgasps=0.000 snapdiffs=311.97KiB triedirty=947.12KiB
INFO [10-27|17:33:55.306] Skipping block preparation before Croissant hard fork number=45,195,699 fork=46,392,500
INFO [10-27|17:33:56.331] Imported new chain segment               number=45,195,699 hash=159983..a23ad4 blocks=1  txs=0 mgas=0.000 elapsed=9.628ms   mgasps=0.000 snapdiffs=312.26KiB triedirty=947.12KiB
INFO [10-27|17:33:56.331] Skipping block preparation before Croissant hard fork number=45,195,700 fork=46,392,500
INFO [10-27|17:33:57.331] Imported new chain segment               number=45,195,700 hash=3dd483..c5a336 blocks=1  txs=0 mgas=0.000 elapsed=11.120ms  mgasps=0.000 snapdiffs=312.55KiB triedirty=947.12KiB
```

This PR removes this redundant log.