### PR TITLE
fix: discard old blocks from futureBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## WBFT Protocol Specification
 
+[![dev-ci](https://github.com/wemixarchive/go-wbft/actions/workflows/dev-ci.yml/badge.svg)](https://github.com/wemixarchive/go-wbft/actions/workflows/dev-ci.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/wemixarchive/go-wbft)
+
 WBFT(WEMIX Byzantine Fault Tolerant) is a consensus algorithm that emphasizes decentralization, adapting Istanbul BFT(https://github.com/ethereum/EIPs/issues/650) and QBFT(https://github.com/Consensys/qbft-formal-spec-and-verification) for use in public blockchains. The following improvements have been implemented:
 
 - Adoption of DPoS(Delegated Proof of Stake): Allows anyone to participate as a validator through staking.

--- a/consensus/wbft/engine/engine.go
+++ b/consensus/wbft/engine/engine.go
@@ -992,7 +992,6 @@ func (e *Engine) GetValidators(chain consensus.ChainHeaderReader, blockNumber *b
 
 	_, epochInfo, err = e.getEpochInfo(chain, blockNumber, parentHash, parents)
 	if err != nil {
-		log.Error("WBFT: failed to get epochInfo", "number", blockNumber, "err", err)
 		return nil, err
 	}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1641,9 +1641,17 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 	// First block is pruned
 	case errors.Is(err, consensus.ErrPrunedAncestor):
 		if setHead {
-			// First block is pruned, insert as sidechain and reorg only if TD grows enough
-			log.Debug("Pruned ancestor, inserting as sidechain", "number", block.Number(), "hash", block.Hash())
-			return bc.insertSideChain(block, it)
+			if bc.Config().CroissantEnabled() {
+				log.Info("Pruned ancestor on Croissant during insertChain, discard the obsolete block", "number", block.Number(), "hash", block.Hash())
+				if bc.futureBlocks.Contains(block.Hash()) {
+					bc.futureBlocks.Remove(block.Hash())
+				}
+				return it.index, nil
+			} else {
+				// First block is pruned, insert as sidechain and reorg only if TD grows enough
+				log.Debug("Pruned ancestor, inserting as sidechain", "number", block.Number(), "hash", block.Hash())
+				return bc.insertSideChain(block, it)
+			}
 		} else {
 			// We're post-merge and the parent is pruned, try to recover the parent state
 			log.Debug("Pruned ancestor", "number", block.Number(), "hash", block.Hash())


### PR DESCRIPTION
- blockchain.go:insertChain
  - wbft does not need to save side chain which is obsolete(parent is pruned)
- engine.go:GetValidators
  - remove error log; this error is normal in the case of processing a future block
- add badges to README

Close #165 