### PR TITLE
feat: support eth_GetReceiptsByHash

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1016,6 +1016,10 @@ func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.
 	return result, nil
 }
 
+func (s *BlockChainAPI) GetReceiptsByHash(ctx context.Context, blockHash common.Hash) ([]map[string]interface{}, error) {
+	return s.GetBlockReceipts(ctx, rpc.BlockNumberOrHashWithHash(blockHash, true))
+}
+
 // OverrideAccount indicates the overriding fields of account during the execution
 // of a message call.
 // Note, state and stateDiff can't be specified at the same time. If state is


### PR DESCRIPTION
- Modified to support the RPC method eth_getReceiptsByHash, which is already supported in Wemix 3.0. 
- Since it performs the same logic as eth_getBlockReceipts, it is implemented to internally call the GetBlockReceipts function.