### PR TITLE
fix: enable sidechain insertion for pruned ancestors

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1641,17 +1641,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 	// First block is pruned
 	case errors.Is(err, consensus.ErrPrunedAncestor):
 		if setHead {
-			if bc.Config().CroissantEnabled() {
-				log.Info("Pruned ancestor on Croissant during insertChain, discard the obsolete block", "number", block.Number(), "hash", block.Hash())
-				if bc.futureBlocks.Contains(block.Hash()) {
-					bc.futureBlocks.Remove(block.Hash())
-				}
-				return it.index, nil
-			} else {
-				// First block is pruned, insert as sidechain and reorg only if TD grows enough
-				log.Debug("Pruned ancestor, inserting as sidechain", "number", block.Number(), "hash", block.Hash())
-				return bc.insertSideChain(block, it)
-			}
+			// First block is pruned, insert as sidechain and reorg only if TD grows enough
+			log.Debug("Pruned ancestor, inserting as sidechain", "number", block.Number(), "hash", block.Hash())
+			return bc.insertSideChain(block, it)
 		} else {
 			// We're post-merge and the parent is pruned, try to recover the parent state
 			log.Debug("Pruned ancestor", "number", block.Number(), "hash", block.Hash())


### PR DESCRIPTION
# Fix sync recovery after abnormal termination

## Summary
Enables state recovery for blocks with missing state tries (e.g., after `kill -9`) by falling back to sidechain insertion logic instead of discarding them.

## Details
- **Problem**: `ErrPrunedAncestor` caused by missing state after abnormal shutdown triggered immediate block discard, permanently blocking sync.
- **Fix**: Removed the discard logic to allow `insertSideChain()` to handle these cases.
- **Result**: `insertSideChain()` detects the need for reorg and executes its internal state recovery logic, allowing the node to heal the chain state automatically.