### PR TITLE
fix: config initialization and parsing improvements

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2097,7 +2097,18 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		gspec   = MakeGenesis(ctx)
 		chainDb = MakeChainDatabase(ctx, stack, readonly)
 	)
-	config, err := core.LoadChainConfig(chainDb, gspec)
+
+	var overrides core.ChainOverrides
+	if ctx.IsSet(OverrideCancun.Name) {
+		v := ctx.Uint64(OverrideCancun.Name)
+		overrides.OverrideCancun = &v
+	}
+	if ctx.IsSet(OverrideVerkle.Name) {
+		v := ctx.Uint64(OverrideVerkle.Name)
+		overrides.OverrideVerkle = &v
+	}
+
+	config, err := core.LoadChainConfigWithOverride(chainDb, gspec, &overrides)
 	if err != nil {
 		Fatalf("%v", err)
 	}
@@ -2144,7 +2155,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 	vmcfg := vm.Config{EnablePreimageRecording: ctx.Bool(VMEnableDebugFlag.Name)}
 
 	// Disable transaction indexing/unindexing by default.
-	chain, err := core.NewBlockChain(chainDb, cache, gspec, nil, engine, vmcfg, nil, nil)
+	chain, err := core.NewBlockChain(chainDb, cache, gspec, &overrides, engine, vmcfg, nil, nil)
 	if err != nil {
 		Fatalf("Can't create BlockChain: %v", err)
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -215,6 +215,39 @@ type ChainOverrides struct {
 	OverrideVerkle *uint64
 }
 
+func applyOverrides(config *params.ChainConfig, overrides *ChainOverrides) {
+	if config == nil {
+		return
+	}
+	if overrides != nil && overrides.OverrideCancun != nil {
+		config.CancunTime = overrides.OverrideCancun
+	}
+	if overrides != nil && overrides.OverrideVerkle != nil {
+		config.VerkleTime = overrides.OverrideVerkle
+	}
+}
+
+func validateCroissantGenesisConfig(config *params.ChainConfig) error {
+	if config != nil && config.CroissantEnabled() && config.CroissantBlock.Sign() == 0 {
+		if err := config.Croissant.CheckValidity(); err != nil {
+			return fmt.Errorf("Invalid genesis config: %v", err)
+		}
+	}
+	return nil
+}
+
+func initializeCroissantGenesis(genesis *Genesis) error {
+	if genesis == nil || genesis.Config == nil || !genesis.Config.CroissantEnabled() || genesis.Config.CroissantBlock.Sign() != 0 {
+		return nil
+	}
+	extraData, err := wbft.CreateInitialExtraData(genesis.Config.Croissant)
+	if err != nil {
+		return err
+	}
+	genesis.ExtraData = extraData
+	return InjectContracts(genesis, genesis.Config)
+}
+
 // SetupGenesisBlock writes or updates the genesis block in db.
 // The block that will be used is:
 //
@@ -236,16 +269,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	if genesis != nil && genesis.Config == nil {
 		return params.AllEthashProtocolChanges, common.Hash{}, errGenesisNoConfig
 	}
-	applyOverrides := func(config *params.ChainConfig) {
-		if config != nil {
-			if overrides != nil && overrides.OverrideCancun != nil {
-				config.CancunTime = overrides.OverrideCancun
-			}
-			if overrides != nil && overrides.OverrideVerkle != nil {
-				config.VerkleTime = overrides.OverrideVerkle
-			}
-		}
-	}
 	// Just commit the new block if there is no stored genesis block.
 	stored := rawdb.ReadCanonicalHash(db, 0)
 	if (stored == common.Hash{}) {
@@ -255,22 +278,14 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		} else {
 			log.Info("Writing custom genesis block")
 		}
-		applyOverrides(genesis.Config)
+		applyOverrides(genesis.Config, overrides)
 
-		if genesis.Config.CroissantEnabled() && genesis.Config.CroissantBlock.Sign() == 0 {
-			if err := genesis.Config.Croissant.CheckValidity(); err != nil {
-				return nil, common.Hash{}, fmt.Errorf("Invalid genesis config: %v", err)
-			}
+		if err := validateCroissantGenesisConfig(genesis.Config); err != nil {
+			return nil, common.Hash{}, err
+		}
 
-			var err error
-			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Croissant)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
-			err = InjectContracts(genesis, genesis.Config)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
+		if err := initializeCroissantGenesis(genesis); err != nil {
+			return genesis.Config, common.Hash{}, err
 		}
 		block, err := genesis.Commit(db, triedb)
 		if err != nil {
@@ -287,21 +302,13 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		if genesis == nil {
 			genesis = DefaultWemixMainnetGenesisBlock()
 		}
-		applyOverrides(genesis.Config)
+		applyOverrides(genesis.Config, overrides)
 
-		if genesis.Config.CroissantEnabled() && genesis.Config.CroissantBlock.Sign() == 0 {
-			if err := genesis.Config.Croissant.CheckValidity(); err != nil {
-				return nil, common.Hash{}, fmt.Errorf("Invalid genesis config: %v", err)
-			}
-			var err error
-			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Croissant)
-			if err != nil {
-				return genesis.Config, stored, err
-			}
-			err = InjectContracts(genesis, genesis.Config)
-			if err != nil {
-				return genesis.Config, stored, err
-			}
+		if err := validateCroissantGenesisConfig(genesis.Config); err != nil {
+			return nil, common.Hash{}, err
+		}
+		if err := initializeCroissantGenesis(genesis); err != nil {
+			return genesis.Config, stored, err
 		}
 
 		// Ensure the stored genesis matches with the given one.
@@ -317,21 +324,12 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 	// Check whether the genesis block is already written.
 	if genesis != nil {
-		applyOverrides(genesis.Config)
-		if genesis.Config.CroissantEnabled() && genesis.Config.CroissantBlock.Sign() == 0 {
-			if err := genesis.Config.Croissant.CheckValidity(); err != nil {
-				return nil, common.Hash{}, fmt.Errorf("Invalid genesis config: %v", err)
-			}
-
-			var err error
-			genesis.ExtraData, err = wbft.CreateInitialExtraData(genesis.Config.Croissant)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
-			err = InjectContracts(genesis, genesis.Config)
-			if err != nil {
-				return genesis.Config, common.Hash{}, err
-			}
+		applyOverrides(genesis.Config, overrides)
+		if err := validateCroissantGenesisConfig(genesis.Config); err != nil {
+			return nil, common.Hash{}, err
+		}
+		if err := initializeCroissantGenesis(genesis); err != nil {
+			return genesis.Config, common.Hash{}, err
 		}
 		hash := genesis.ToBlock().Hash()
 		if hash != stored {
@@ -340,7 +338,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 	// Get the existing chain configuration.
 	newcfg := genesis.configOrDefault(stored)
-	applyOverrides(newcfg)
+	applyOverrides(newcfg, overrides)
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
 		return newcfg, common.Hash{}, err
 	}
@@ -358,7 +356,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	// apply the overrides.
 	if genesis == nil && stored != params.MainnetGenesisHash && stored != params.WemixMainnetGenesisHash {
 		newcfg = storedcfg
-		applyOverrides(newcfg)
+		applyOverrides(newcfg, overrides)
 	}
 	// Check config compatibility and write the config. Compatibility errors
 	// are returned to the caller unless we're already at block zero.
@@ -375,6 +373,64 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		rawdb.WriteChainConfig(db, stored, newcfg)
 	}
 	return newcfg, stored, nil
+}
+
+// LoadChainConfigWithOverride loads the chain configuration from the database if present,
+// otherwise returns the config from the provided genesis specification, with overrides applied.
+func LoadChainConfigWithOverride(db ethdb.Database, genesis *Genesis, overrides *ChainOverrides) (*params.ChainConfig, error) {
+	if genesis != nil && genesis.Config == nil {
+		return params.AllEthashProtocolChanges, errGenesisNoConfig
+	}
+
+	stored := rawdb.ReadCanonicalHash(db, 0)
+	// If no genesis block is stored, use the provided genesis or default
+	if (stored == common.Hash{}) {
+		if genesis == nil {
+			genesis = DefaultWemixMainnetGenesisBlock()
+		}
+		if genesis.Config == nil {
+			return params.AllEthashProtocolChanges, errGenesisNoConfig
+		}
+		applyOverrides(genesis.Config, overrides)
+		return genesis.Config, nil
+	}
+
+	// If a canonical genesis already exists and a genesis is provided, ensure
+	// the provided genesis does not point to a different chain.
+	if genesis != nil {
+		applyOverrides(genesis.Config, overrides)
+		if err := validateCroissantGenesisConfig(genesis.Config); err != nil {
+			return nil, err
+		}
+		if err := initializeCroissantGenesis(genesis); err != nil {
+			return genesis.Config, err
+		}
+		hash := genesis.ToBlock().Hash()
+		if hash != stored {
+			return genesis.Config, &GenesisMismatchError{Stored: stored, New: hash}
+		}
+	}
+
+	// Genesis exists, get the config
+	newcfg := genesis.configOrDefault(stored)
+	applyOverrides(newcfg, overrides)
+
+	// Validate fork order
+	if err := newcfg.CheckConfigForkOrder(); err != nil {
+		return newcfg, err
+	}
+
+	// Check if there's a stored config in the database
+	storedcfg := rawdb.ReadChainConfig(db, stored)
+	if storedcfg != nil {
+		// Special case: private network - use stored config with overrides
+		if genesis == nil && stored != params.MainnetGenesisHash && stored != params.WemixMainnetGenesisHash {
+			newcfg = storedcfg
+			applyOverrides(newcfg, overrides)
+		}
+	}
+
+	return newcfg, nil
 }
 
 // LoadChainConfig loads the stored chain config if it is already present in

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -49,6 +49,117 @@ func TestSetupGenesis(t *testing.T) {
 	testSetupGenesis(t, rawdb.PathScheme)
 }
 
+func TestLoadChainConfigWithOverride(t *testing.T) {
+	t.Run("no block in DB, genesis with overrides", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		cancunTime := uint64(1234)
+
+		config := *params.TestChainConfig
+		genesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+		got, err := LoadChainConfigWithOverride(db, genesis, &ChainOverrides{OverrideCancun: &cancunTime})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.CancunTime == nil || *got.CancunTime != cancunTime {
+			t.Fatalf("override not applied, got=%v want=%d", got.CancunTime, cancunTime)
+		}
+	})
+
+	t.Run("private network in DB, genesis nil uses stored config with overrides", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		verkleTime := uint64(5678)
+
+		config := *params.TestChainConfig
+		config.ChainID = big.NewInt(1337)
+		genesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+		block := genesis.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+
+		got, err := LoadChainConfigWithOverride(db, nil, &ChainOverrides{OverrideVerkle: &verkleTime})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ChainID.Cmp(config.ChainID) != 0 {
+			t.Fatalf("unexpected chain id, got=%v want=%v", got.ChainID, config.ChainID)
+		}
+		if got.VerkleTime == nil || *got.VerkleTime != verkleTime {
+			t.Fatalf("override not applied, got=%v want=%d", got.VerkleTime, verkleTime)
+		}
+		storedcfg := rawdb.ReadChainConfig(db, block.Hash())
+		if storedcfg == nil {
+			t.Fatalf("stored chain config missing")
+		}
+		if storedcfg.ChainID.Cmp(got.ChainID) != 0 {
+			t.Fatalf("unexpected stored chain id, got=%v want=%v", storedcfg.ChainID, got.ChainID)
+		}
+	})
+
+	t.Run("stored genesis with mismatching provided genesis returns mismatch error", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+
+		config := *params.TestChainConfig
+		config.ChainID = big.NewInt(9999)
+		storedGenesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+		block := storedGenesis.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+
+		mismatchGenesis := &Genesis{
+			Config:     &config,
+			GasLimit:   4712388,
+			Difficulty: big.NewInt(1),
+			Nonce:      1, // force different genesis hash
+			Alloc: types.GenesisAlloc{
+				{1}: {Balance: big.NewInt(1)},
+			},
+		}
+
+		_, err := LoadChainConfigWithOverride(db, mismatchGenesis, nil)
+		if err == nil {
+			t.Fatalf("expected mismatch error")
+		}
+		mismatchErr, ok := err.(*GenesisMismatchError)
+		if !ok {
+			t.Fatalf("unexpected error type: %T", err)
+		}
+		if mismatchErr.Stored != block.Hash() {
+			t.Fatalf("unexpected stored hash, got=%s want=%s", mismatchErr.Stored, block.Hash())
+		}
+		if mismatchErr.New != mismatchGenesis.ToBlock().Hash() {
+			t.Fatalf("unexpected new hash, got=%s want=%s", mismatchErr.New, mismatchGenesis.ToBlock().Hash())
+		}
+	})
+
+	t.Run("genesis without config returns errGenesisNoConfig", func(t *testing.T) {
+		db := rawdb.NewMemoryDatabase()
+		got, err := LoadChainConfigWithOverride(db, new(Genesis), nil)
+		if err != errGenesisNoConfig {
+			t.Fatalf("unexpected error, got=%v want=%v", err, errGenesisNoConfig)
+		}
+		if got != params.AllEthashProtocolChanges {
+			t.Fatalf("unexpected config return for error path")
+		}
+	})
+}
+
 func testSetupGenesis(t *testing.T, scheme string) {
 	var (
 		customghash = common.HexToHash("0x89c99d90b79719238d2645c7642f2c9295246e80775b38cfd162b696817fbd50")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -146,8 +146,18 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			log.Error("Failed to recover state", "error", err)
 		}
 	}
+
+	// Override the chain config with provided settings.
+	var overrides core.ChainOverrides
+	if config.OverrideCancun != nil {
+		overrides.OverrideCancun = config.OverrideCancun
+	}
+	if config.OverrideVerkle != nil {
+		overrides.OverrideVerkle = config.OverrideVerkle
+	}
+
 	// Transfer mining-related config to the ethash config.
-	chainConfig, err := core.LoadChainConfig(chainDb, config.Genesis)
+	chainConfig, err := core.LoadChainConfigWithOverride(chainDb, config.Genesis, &overrides)
 	if err != nil {
 		return nil, err
 	}
@@ -216,14 +226,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			StateScheme:         scheme,
 		}
 	)
-	// Override the chain config with provided settings.
-	var overrides core.ChainOverrides
-	if config.OverrideCancun != nil {
-		overrides.OverrideCancun = config.OverrideCancun
-	}
-	if config.OverrideVerkle != nil {
-		overrides.OverrideVerkle = config.OverrideVerkle
-	}
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err

--- a/wemixgov/governance-wbft/governance.go
+++ b/wemixgov/governance-wbft/governance.go
@@ -106,7 +106,10 @@ func GetGovContractsTransition(govContracts *params.GovContracts) (*params.State
 
 	if govContracts.GovNCP != nil {
 		st.Codes = append(st.Codes, params.CodeParam{Address: govContracts.GovNCP.Address, Code: GovContractCodes[CONTRACT_GOV_NCP][govContracts.GovNCP.Version]})
-		ncpAddresses := strings.Split(govContracts.GovNCP.Params[GOV_NCP_PARAM_NCPS], ",")
+		ncpAddresses := splitAndTrim(govContracts.GovNCP.Params[GOV_NCP_PARAM_NCPS], ",")
+		if len(ncpAddresses) == 0 {
+			return nil, errors.New("govNCP is configured but no initial NCPs provided")
+		}
 		ncps := make([]common.Address, 0)
 		for _, ncp := range ncpAddresses {
 			ncps = append(ncps, common.HexToAddress(ncp))
@@ -207,4 +210,15 @@ func NCPStakerInfoMap(govStakingAddress, govNCPAddress common.Address, state Sta
 		stakerInfos[v] = StakerInfo(govStakingAddress, state, v)
 	}
 	return stakerInfos
+}
+
+func splitAndTrim(s, sep string) (ret []string) {
+	l := strings.Split(s, sep)
+	for _, r := range l {
+		r = strings.TrimSpace(r)
+		if len(r) > 0 {
+			ret = append(ret, r)
+		}
+	}
+	return ret
 }


### PR DESCRIPTION
## Summary

Fix chain config initialization and comma-separated config string parsing issues.

## Changes

### 1. Normalize comma-separated NCP config string

- Use `splitAndTrim` instead of raw `strings.Split` for NCP address parsing during system contract initialization
- Trims whitespace and drops empty entries to prevent zero-address registration
- Returns error if `govNCP` is configured but no initial NCPs are provided

### 2. Resolve chainconfig engine mismatch

- Add `LoadChainConfigWithOverride` to resolve the final `ChainConfig` with overrides applied before engine creation
- Previously, the WBFT engine was initialized with a stale `ChainConfig` from the database, before overrides were applied in `NewBlockChain`, causing a mismatch
- Extract `validateCroissantGenesisConfig` and `initializeCroissantGenesis` helper functions
- Move override construction before engine creation in `eth/backend.go`
- Add `TestLoadChainConfigWithOverride`