### PR TITLE
trie: do not expect ordering in stacktrie during fuzzing (#31170)

### DIFF
--- a/trie/stacktrie_fuzzer_test.go
+++ b/trie/stacktrie_fuzzer_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/trie/trienode"
-	"golang.org/x/crypto/sha3"
 )
 
 func FuzzStackTrie(f *testing.F) {
@@ -38,16 +37,13 @@ func FuzzStackTrie(f *testing.F) {
 }
 
 func fuzz(data []byte, debugging bool) {
-	// This spongeDb is used to check the sequence of disk-db-writes
 	var (
-		input   = bytes.NewReader(data)
-		spongeA = &spongeDb{sponge: sha3.NewLegacyKeccak256()}
-		dbA     = newTestDatabase(rawdb.NewDatabase(spongeA), rawdb.HashScheme)
-		trieA   = NewEmpty(dbA)
-		spongeB = &spongeDb{sponge: sha3.NewLegacyKeccak256()}
-		dbB     = newTestDatabase(rawdb.NewDatabase(spongeB), rawdb.HashScheme)
-		trieB   = NewStackTrie(func(path []byte, hash common.Hash, blob []byte) {
-			rawdb.WriteTrieNode(spongeB, common.Hash{}, path, hash, blob, dbB.Scheme())
+		input = bytes.NewReader(data)
+		dbA   = newTestDatabase(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
+		trieA = NewEmpty(dbA)
+		memDB = rawdb.NewMemoryDatabase()
+		trieB = NewStackTrie(func(path []byte, hash common.Hash, blob []byte) {
+			rawdb.WriteTrieNode(memDB, common.Hash{}, path, hash, blob, rawdb.HashScheme)
 		})
 		vals        []*kv
 		maxElements = 10000
@@ -56,13 +52,17 @@ func fuzz(data []byte, debugging bool) {
 	)
 	// Fill the trie with elements
 	for i := 0; input.Len() > 0 && i < maxElements; i++ {
+		// Build the key
 		k := make([]byte, 32)
 		input.Read(k)
+
+		// Build the val
 		var a uint16
 		binary.Read(input, binary.LittleEndian, &a)
 		a = 1 + a%100
 		v := make([]byte, a)
 		input.Read(v)
+
 		if input.Len() == 0 {
 			// If it was exhausted while reading, the value may be all zeroes,
 			// thus 'deletion' which is not supported on stacktrie
@@ -74,6 +74,7 @@ func fuzz(data []byte, debugging bool) {
 		}
 		keys[string(k)] = struct{}{}
 		vals = append(vals, &kv{k: k, v: v})
+
 		trieA.MustUpdate(k, v)
 	}
 	if len(vals) == 0 {
@@ -102,11 +103,6 @@ func fuzz(data []byte, debugging bool) {
 	rootB := trieB.Hash()
 	if rootA != rootB {
 		panic(fmt.Sprintf("roots differ: (trie) %x != %x (stacktrie)", rootA, rootB))
-	}
-	sumA := spongeA.sponge.Sum(nil)
-	sumB := spongeB.sponge.Sum(nil)
-	if !bytes.Equal(sumA, sumB) {
-		panic(fmt.Sprintf("sequence differ: (trie) %x != %x (stacktrie)", sumA, sumB))
 	}
 
 	// Ensure all the nodes are persisted correctly

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -928,7 +928,6 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 		{200, common.FromHex("dde92ca9812e068e6982d04b40846dc65a61a9fd4996fc0f55f2fde172a8e13c")},
 		{2000, common.FromHex("ab553a7f9aff82e3929c382908e30ef7dd17a332933e92ba3fe873fc661ef382")},
 	} {
-		// This spongeDb is used to check the sequence of disk-db-writes
 		prng := rand.New(rand.NewSource(int64(i)))
 		// This spongeDb is used to check the sequence of disk-db-writes
 		s := &spongeDb{sponge: sha3.NewLegacyKeccak256()}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -930,7 +930,8 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 	} {
 		// This spongeDb is used to check the sequence of disk-db-writes
 		prng := rand.New(rand.NewSource(int64(i)))
-		s := &spongeDb{sponge: crypto.NewKeccakState()}
+		// This spongeDb is used to check the sequence of disk-db-writes
+		s := &spongeDb{sponge: sha3.NewLegacyKeccak256()}
 		db := newTestDatabase(rawdb.NewDatabase(s), rawdb.HashScheme)
 
 		// Fill the trie with elements

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -777,6 +777,7 @@ func TestCommitAfterHash(t *testing.T) {
 func makeAccounts(size int) (addresses [][20]byte, accounts [][]byte) {
 	// Make the random benchmark deterministic
 	random := rand.New(rand.NewSource(0))
+
 	// Create a realistic account trie to hash
 	addresses = make([][20]byte, size)
 	for i := 0; i < len(addresses); i++ {
@@ -793,13 +794,18 @@ func makeAccounts(size int) (addresses [][20]byte, accounts [][]byte) {
 		)
 		// The big.Rand function is not deterministic with regards to 64 vs 32 bit systems,
 		// and will consume different amount of data from the rand source.
-		//balance = new(big.Int).Rand(random, new(big.Int).Exp(common.Big2, common.Big256, nil))
+		// balance = new(big.Int).Rand(random, new(big.Int).Exp(common.Big2, common.Big256, nil))
 		// Therefore, we instead just read via byte buffer
 		numBytes := random.Uint32() % 33 // [0, 32] bytes
 		balanceBytes := make([]byte, numBytes)
 		random.Read(balanceBytes)
 		balance := new(uint256.Int).SetBytes(balanceBytes)
-		data, _ := rlp.EncodeToBytes(&types.StateAccount{Nonce: nonce, Balance: balance, Root: root, CodeHash: code})
+		data, _ := rlp.EncodeToBytes(&types.StateAccount{
+			Nonce:    nonce,
+			Balance:  balance,
+			Root:     root,
+			CodeHash: code,
+		})
 		accounts[i] = data
 	}
 	return addresses, accounts
@@ -854,6 +860,7 @@ func (s *spongeDb) Flush() {
 		s.sponge.Write([]byte(key))
 		s.sponge.Write([]byte(s.values[key]))
 	}
+	fmt.Println(len(s.keys))
 }
 
 // spongeBatch is a dummy batch which immediately writes to the underlying spongedb
@@ -871,10 +878,12 @@ func (b *spongeBatch) Write() error                        { return nil }
 func (b *spongeBatch) Reset()                              {}
 func (b *spongeBatch) Replay(w ethdb.KeyValueWriter) error { return nil }
 
-// TestCommitSequence tests that the trie.Commit operation writes the elements of the trie
-// in the expected order.
-// The test data was based on the 'master' code, and is basically random. It can be used
-// to check whether changes to the trie modifies the write order or data in any way.
+// TestCommitSequence tests that the trie.Commit operation writes the elements
+// of the trie in the expected order.
+//
+// The test data was based on the 'master' code, and is basically random.
+// It can be used to check whether changes to the trie modifies the write order
+// or data in any way.
 func TestCommitSequence(t *testing.T) {
 	for i, tc := range []struct {
 		count           int
@@ -885,19 +894,23 @@ func TestCommitSequence(t *testing.T) {
 		{2000, common.FromHex("4574cd8e6b17f3fe8ad89140d1d0bf4f1bd7a87a8ac3fb623b33550544c77635")},
 	} {
 		addresses, accounts := makeAccounts(tc.count)
+
 		// This spongeDb is used to check the sequence of disk-db-writes
 		s := &spongeDb{sponge: sha3.NewLegacyKeccak256()}
 		db := newTestDatabase(rawdb.NewDatabase(s), rawdb.HashScheme)
-		trie := NewEmpty(db)
+
 		// Fill the trie with elements
+		trie := NewEmpty(db)
 		for i := 0; i < tc.count; i++ {
 			trie.MustUpdate(crypto.Keccak256(addresses[i][:]), accounts[i])
 		}
 		// Flush trie -> database
 		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+
 		// Flush memdb -> disk (sponge)
 		db.Commit(root)
+
 		if got, exp := s.sponge.Sum(nil), tc.expWriteSeqHash; !bytes.Equal(got, exp) {
 			t.Errorf("test %d, disk write sequence wrong:\ngot %x exp %x\n", i, got, exp)
 		}
@@ -915,12 +928,13 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 		{200, common.FromHex("dde92ca9812e068e6982d04b40846dc65a61a9fd4996fc0f55f2fde172a8e13c")},
 		{2000, common.FromHex("ab553a7f9aff82e3929c382908e30ef7dd17a332933e92ba3fe873fc661ef382")},
 	} {
-		prng := rand.New(rand.NewSource(int64(i)))
 		// This spongeDb is used to check the sequence of disk-db-writes
-		s := &spongeDb{sponge: sha3.NewLegacyKeccak256()}
+		prng := rand.New(rand.NewSource(int64(i)))
+		s := &spongeDb{sponge: crypto.NewKeccakState()}
 		db := newTestDatabase(rawdb.NewDatabase(s), rawdb.HashScheme)
-		trie := NewEmpty(db)
+
 		// Fill the trie with elements
+		trie := NewEmpty(db)
 		for i := 0; i < tc.count; i++ {
 			key := make([]byte, 32)
 			var val []byte
@@ -937,6 +951,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 		// Flush trie -> database
 		root, nodes, _ := trie.Commit(false)
 		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+
 		// Flush memdb -> disk (sponge)
 		db.Commit(root)
 		if got, exp := s.sponge.Sum(nil), tc.expWriteSeqHash; !bytes.Equal(got, exp) {
@@ -972,14 +987,16 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 			// For the stack trie, we need to do inserts in proper order
 			key := make([]byte, 32)
 			binary.BigEndian.PutUint64(key, uint64(i))
-			var val []byte
+
 			// 50% short elements, 50% large elements
+			var val []byte
 			if prng.Intn(2) == 0 {
 				val = make([]byte, 1+prng.Intn(32))
 			} else {
 				val = make([]byte, 1+prng.Intn(1024))
 			}
 			prng.Read(val)
+
 			trie.Update(key, val)
 			stTrie.Update(key, val)
 		}


### PR DESCRIPTION
## Summary
Backport of go-ethereum PR #31170.

This change updates trie fuzz tests to avoid assuming identical ordering between `stacktrie` and `trie`.

## Background
The previous fuzz test logic assumed that `stacktrie` and `trie` would produce results in the same order.
However, upstream identified cases through OSS-Fuzz where this assumption does not always hold.

As part of the upstream fix, the fuzz test setup was also adjusted to use a memory-backed test database instead of the previous sponge DB-based path in this flow.

## Upstream References
| Reference | Description |
|-----------|-------------|
| PR [#31170](https://github.com/ethereum/go-ethereum/pull/31170) | removes the assumption of the stacktrie and trie to have the same ordering. |


## Changes
- remove ordering assumptions in trie fuzz tests
- update the fuzz test database setup for this path
- align trie fuzz behavior with upstream go-ethereum

## Why this is needed
- prevent false failures in fuzz testing
- match upstream trie fuzz test behavior
- improve robustness of fuzz-based trie validation

## Impact
- test-only change
- no runtime behavior change
- no consensus or state transition impact

## Notes
- this is a backport from upstream go-ethereum
- no functional changes were introduced outside the test path