### PR TITLE
fix: resolve data races in wbft consensus core

### DIFF
--- a/consensus/wbft/backend/engine_test.go
+++ b/consensus/wbft/backend/engine_test.go
@@ -52,10 +52,9 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 )
 
-var blockEnqueueChannel chan *types.Block
-
 type fakeBroadcaster struct {
-	blockFetcher *fetcher.BlockFetcher
+	blockFetcher        *fetcher.BlockFetcher
+	blockEnqueueChannel chan *types.Block
 }
 
 type otherNode struct {
@@ -65,7 +64,6 @@ type otherNode struct {
 }
 
 func makeFakeBroadcaster(chain *core.BlockChain) *fakeBroadcaster {
-	blockEnqueueChannel = make(chan *types.Block)
 	validator := func(header *types.Header) error {
 		return chain.Engine().VerifyHeader(chain, header)
 	}
@@ -76,26 +74,16 @@ func makeFakeBroadcaster(chain *core.BlockChain) *fakeBroadcaster {
 		return chain.CurrentBlock().Number.Uint64()
 	}
 
-	//inserter := func(blocks types.Blocks) (int, error) {
-	//	idx, err := chain.InsertChain(blocks)
-	//	if err == nil {
-	//		header := blocks[len(blocks)-1].Header()
-	//		chain.SetFinalized(header)
-	//		chain.SetSafe(header)
-	//	}
-	//	// ## Wemix END
-	//	return idx, err
-	//}
-
 	fb := fakeBroadcaster{
-		blockFetcher: fetcher.NewBlockFetcher(false, nil, chain.GetBlockByHash, validator, broadcastBlock, heighter, nil, nil, nil),
+		blockFetcher:        fetcher.NewBlockFetcher(false, nil, chain.GetBlockByHash, validator, broadcastBlock, heighter, nil, nil, nil),
+		blockEnqueueChannel: make(chan *types.Block),
 	}
 	fb.blockFetcher.Start()
 	return &fb
 }
 
 func (fb *fakeBroadcaster) Enqueue(id string, block *types.Block) {
-	go func() { blockEnqueueChannel <- block }()
+	go func() { fb.blockEnqueueChannel <- block }()
 }
 
 func (fb *fakeBroadcaster) FindPeers(targets map[common.Address]bool) map[common.Address]consensus.Peer {
@@ -211,17 +199,20 @@ func makeBlock(chain *core.BlockChain, engine *Backend, parent *types.Block) *ty
 
 // makeBlock create block executing no txs without seal
 func makeBlockWithoutSeal(chain *core.BlockChain, engine *Backend, parent *types.Block) *types.Block {
-	engine.NewChainHead() // progress to next sequence
-	if engine.core.GetState() != wbftcore.StateAcceptRequest {
-		ticker := time.NewTicker(100 * time.Millisecond)
-		for {
-			<-ticker.C
-			if engine.core.GetState() == wbftcore.StateAcceptRequest {
-				ticker.Stop()
-				break
-			}
-		}
+	sub := engine.EventMux().Subscribe(wbft.FinalCommittedEvent{})
+	defer sub.Unsubscribe()
+
+	if err := engine.NewChainHead(); err != nil {
+		panic("NewChainHead failed: " + err.Error())
 	}
+
+	select {
+	case <-sub.Chan():
+		break
+	case <-time.After(10 * time.Second):
+		panic("timeout waiting for FinalCommittedEvent")
+	}
+
 	header := makeHeader(chain.Config(), engine.config, parent)
 	engine.Prepare(chain, header)
 	block := types.NewBlock(header, nil, nil, nil, trie.NewStackTrie(nil))

--- a/consensus/wbft/backend/multiengine_test.go
+++ b/consensus/wbft/backend/multiengine_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,9 +56,9 @@ type testEnv struct {
 	// properties for test scenario
 	down        map[common.Address]bool
 	msgDisabled map[common.Address]map[uint64]bool
+	mu          sync.RWMutex
 }
 
-// make n engines with given genesis and cfg
 func MakeMultiEngineTestEnv(n int) (env *testEnv) {
 	env = &testEnv{}
 
@@ -82,6 +83,17 @@ func MakeMultiEngineTestEnv(n int) (env *testEnv) {
 	env.engines = make(map[common.Address]*Backend)
 	env.subResult = make(chan *types.Block)
 	for i, nodeKey := range nodeKeys {
+		// Each engine must have its own Config (and thus its own ProposerPolicy);
+		// otherwise Start() -> startWBFT() -> ProposerPolicy.Use() causes a data race
+		// when multiple engines are started concurrently (go engine.Start(...)).
+		config := new(wbft.Config)
+		wbft.SetConfigFromChainConfig(config, genesis.Config)
+		config.BlockPeriod = 1
+		config.Epoch = 4
+		config.RequestTimeout = 2000
+		config.MaxRequestTimeoutSeconds = 2
+		config.AllowedFutureBlockTime = 100000000 // to skip future block check; this makes block creation time to be very short
+
 		addr := crypto.PubkeyToAddress(nodeKey.PublicKey)
 		memDB := rawdb.NewMemoryDatabase()
 		env.addrs[i] = addr
@@ -251,6 +263,8 @@ func (env *testEnv) makeScenarioEngineDown(index ...int) *scenario {
 	return &scenario{
 		target: append([]int{}, index...),
 		set: func(i int) string {
+			env.mu.Lock()
+			defer env.mu.Unlock()
 			env.down[env.addrs[i]] = true
 			return fmt.Sprintf("[%d:down]", i)
 		},
@@ -261,6 +275,8 @@ func (env *testEnv) makeScenarioEngineUp(index ...int) *scenario {
 	return &scenario{
 		target: append([]int{}, index...),
 		set: func(i int) string {
+			env.mu.Lock()
+			defer env.mu.Unlock()
 			env.down[env.addrs[i]] = false
 			return fmt.Sprintf("[%d:up]", i)
 		},
@@ -271,6 +287,8 @@ func (env *testEnv) makeScenarioDisableCommitMsg(index ...int) *scenario {
 	return &scenario{
 		target: append([]int{}, index...),
 		set: func(i int) string {
+			env.mu.Lock()
+			defer env.mu.Unlock()
 			if env.msgDisabled[env.addrs[i]] == nil {
 				env.msgDisabled[env.addrs[i]] = make(map[uint64]bool)
 			}
@@ -284,6 +302,8 @@ func (env *testEnv) makeScenarioEnableCommitMsg(index ...int) *scenario {
 	return &scenario{
 		target: append([]int{}, index...),
 		set: func(i int) string {
+			env.mu.Lock()
+			defer env.mu.Unlock()
 			if env.msgDisabled[env.addrs[i]] == nil {
 				env.msgDisabled[env.addrs[i]] = make(map[uint64]bool)
 			}
@@ -297,6 +317,8 @@ func (env *testEnv) makeScenarioOnlyOneDown(index int) *scenario {
 	return &scenario{
 		target: append([]int{}, index),
 		set: func(i int) string {
+			env.mu.Lock()
+			defer env.mu.Unlock()
 			for j := 0; j < len(env.addrs); j++ {
 				if j == i {
 					env.down[env.addrs[j]] = true
@@ -314,6 +336,8 @@ func (env *testEnv) makeScenarioRandomDown(index ...int) *scenario {
 	return &scenario{
 		target: append([]int{}, index...),
 		set: func(i int) string {
+			env.mu.Lock()
+			defer env.mu.Unlock()
 			if i == x {
 				env.down[env.addrs[i]] = true
 				return fmt.Sprintf("[%d:down]", i)
@@ -392,11 +416,18 @@ type simPeer struct {
 }
 
 func (sp *simPeer) SendWBFTConsensus(msgcode uint64, payload []byte) error {
-	if (sp.br.env.msgDisabled[sp.br.myAddr] != nil && sp.br.env.msgDisabled[sp.br.myAddr][msgcode]) ||
-		(sp.br.env.msgDisabled[sp.peerAddr] != nil && sp.br.env.msgDisabled[sp.peerAddr][msgcode]) ||
-		sp.br.env.down[sp.br.myAddr] || sp.br.env.down[sp.peerAddr] {
+	env := sp.br.env
+	env.mu.RLock()
+	disabledMy := env.msgDisabled[sp.br.myAddr] != nil && env.msgDisabled[sp.br.myAddr][msgcode]
+	disabledPeer := env.msgDisabled[sp.peerAddr] != nil && env.msgDisabled[sp.peerAddr][msgcode]
+	downMy := env.down[sp.br.myAddr]
+	downPeer := env.down[sp.peerAddr]
+	env.mu.RUnlock()
+
+	if disabledMy || disabledPeer || downMy || downPeer {
 		return nil
 	}
+
 	if err := sp.peerEngine.istanbulEventMux.Post(wbft.MessageEvent{
 		Code:    msgcode,
 		Payload: payload,

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -103,12 +103,13 @@ type Core struct {
 	priorState        priorState
 
 	current      *roundState
-	currentMutex sync.Mutex
+	currentMutex sync.RWMutex
 	handlerWg    *sync.WaitGroup
 
 	roundChangeSet          *roundChangeSet
 	roundChangeTimer        *time.Timer
 	lastSentTimeoutCanceled *bool
+	timerMu                 sync.Mutex // protects roundChangeTimer, lastSentTimeoutCanceled, and timer stop/start
 
 	retrySendingRoundChangeTimer *time.Timer
 
@@ -151,6 +152,8 @@ func (c *Core) GetProposer() common.Address {
 }
 
 func (c *Core) IsCurrentProposal(blockHash common.Hash) bool {
+	c.currentMutex.RLock()
+	defer c.currentMutex.RUnlock()
 	return c.current != nil && c.current.pendingRequest != nil && c.current.pendingRequest.Proposal.Hash() == blockHash
 }
 
@@ -311,19 +314,27 @@ func (c *Core) stopFuturePreprepareTimer() {
 		c.futurePreprepareTimer.Stop()
 	}
 }
-
+func (c *Core) stopRoundChangeTimer() {
+	if c.roundChangeTimer != nil {
+		c.roundChangeTimer.Stop()
+	}
+}
+func (c *Core) cancelLastSentTimeout() {
+	if c.lastSentTimeoutCanceled != nil {
+		*c.lastSentTimeoutCanceled = true
+	}
+}
 func (c *Core) stopTimer() {
+	c.timerMu.Lock()
+	defer c.timerMu.Unlock()
 	c.stopFuturePreprepareTimer()
 
 	// Stop retry sending ROUND-CHANGE retry timer
 	c.stopRetrySendingRoundChangeTimer()
 
-	if c.roundChangeTimer != nil {
-		c.roundChangeTimer.Stop()
-	}
-	if c.lastSentTimeoutCanceled != nil {
-		*c.lastSentTimeoutCanceled = true
-	}
+	c.stopRoundChangeTimer()
+
+	c.cancelLastSentTimeout()
 }
 
 func (c *Core) newRoundChangeTimer() {
@@ -375,11 +386,13 @@ func (c *Core) newRoundChangeTimer() {
 	}
 
 	c.currentLogger(true, nil).Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
+	c.timerMu.Lock()
 	c.lastSentTimeoutCanceled = new(bool)
 	*c.lastSentTimeoutCanceled = false
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
 		c.sendEvent(timeoutEvent{c.lastSentTimeoutCanceled})
 	})
+	c.timerMu.Unlock()
 }
 
 // stopRetrySendingRoundChangeTimer stops the round-change retry timer if running.
@@ -389,18 +402,32 @@ func (c *Core) stopRetrySendingRoundChangeTimer() {
 	}
 }
 
-// newRetrySendingRoundChangeTimer sets a retry timer to reattempt round-change after a timeout
+// newRetrySendingRoundChangeTimer sets a retry timer to reattempt round-change after a timeout.
+// It copies round (and seq for config) under currentMutex; the callback uses only that copied round and never reads c.current.
 func (c *Core) newRetrySendingRoundChangeTimer() {
-	c.stopRetrySendingRoundChangeTimer()
+	// Snapshot current view under lock to avoid races with startNewRound/updateRoundState.
+	var seq, round *big.Int
+	c.currentMutex.RLock()
+	if c.current != nil {
+		seq = new(big.Int).Set(c.current.Sequence())
+		round = new(big.Int).Set(c.current.Round())
+	}
+	c.currentMutex.RUnlock()
+	if seq == nil || round == nil {
+		return
+	}
 
-	// set timeout based on the round number
-	cfg := c.config.GetConfig(c.current.Sequence())
+	cfg := c.config.GetConfig(seq)
 	timeout := time.Duration(cfg.RequestTimeout) * time.Millisecond
 
-	c.currentLogger(true, nil).Trace("WBFT: set ROUND-CHANGE retry timer", "round", c.current.Round(), "timeout", timeout.Seconds())
+	c.logger.Trace("WBFT: set ROUND-CHANGE retry timer", "round", round.Uint64(), "timeout", timeout.Seconds())
+
+	c.timerMu.Lock()
+	c.stopRetrySendingRoundChangeTimer()
 	c.retrySendingRoundChangeTimer = time.AfterFunc(timeout, func() {
-		c.sendEvent(retryTimeoutEvent{c.current.Round()})
+		c.sendEvent(retryTimeoutEvent{round})
 	})
+	c.timerMu.Unlock()
 }
 
 func (c *Core) checkValidatorSignature(data []byte, sig []byte, view wbft.View) (common.Address, error) {

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -258,8 +258,15 @@ func (c *Core) startNewRound(round *big.Int) {
 	c.backend.NotifyNewRound(round)
 
 	// the order of NotifyNewRound() and newRoundChangeTimer() does not matter on actual consensus, but
-	// it matters on multi-engine test, so we keep the order as it is
-	c.newRoundChangeTimer()
+	// it matters on multi-engine test, so we keep the order as it is.
+	//
+	// currentMutex.Lock() is held here (see top of startNewRound); snapshot the
+	// view fields directly and pass them to newRoundChangeTimer, which no
+	// longer touches c.current.
+	c.newRoundChangeTimer(
+		new(big.Int).Set(c.current.Sequence()),
+		new(big.Int).Set(c.current.Round()),
+	)
 
 	oldLogger.Info("WBFT: start new round", "next.round", newView.Round, "next.seq", newView.Sequence, "next.proposer", c.valSet.GetProposer(), "next.valSet", c.valSet.List(), "next.size", c.valSet.Size(), "next.IsProposer", c.IsProposer())
 }
@@ -337,18 +344,28 @@ func (c *Core) stopTimer() {
 	c.cancelLastSentTimeout()
 }
 
-func (c *Core) newRoundChangeTimer() {
+// newRoundChangeTimer schedules a ROUND-CHANGE timer for the given view.
+// The caller must snapshot seq/round under currentMutex (Lock or RLock) before
+// calling this function; the implementation does not access c.current. This
+// mirrors newRetrySendingRoundChangeTimer's snapshot contract and removes the
+// previous unsynchronized reads of c.current (spin-wait + Sequence/Round calls).
+//
+// If seq or round is nil (e.g. called before c.current is initialized) the
+// function skips scheduling and returns after stopping any prior timer.
+func (c *Core) newRoundChangeTimer(seq, round *big.Int) {
 	c.stopTimer()
 
-	for c.current == nil { // wait because it is asynchronous in handleRequest
-		time.Sleep(10 * time.Millisecond)
+	if seq == nil || round == nil {
+		c.logger.Warn("WBFT: newRoundChangeTimer skipped: current view not initialized")
+		return
 	}
 
 	// set timeout based on the round number
-	cfg := c.config.GetConfig(c.current.Sequence())
+	cfg := c.config.GetConfig(seq)
 	baseTimeout := time.Duration(cfg.RequestTimeout) * time.Millisecond
-	round := c.current.Round().Uint64()
+	roundNum := round.Uint64()
 	maxRequestTimeout := time.Duration(cfg.MaxRequestTimeoutSeconds) * time.Second
+	logger := c.logger.New("current.round", roundNum, "current.sequence", seq.Uint64())
 
 	// If the upper limit of the request timeout is capped by small maxRequestTimeout, round can be a quite large number,
 	// which leads to float64 overflow, making its value negative or zero forever after some point.
@@ -356,7 +373,7 @@ func (c *Core) newRoundChangeTimer() {
 	var timeout time.Duration
 	if maxRequestTimeout > time.Duration(0) {
 		timeout = baseTimeout
-		for i := uint64(0); i < round; i++ {
+		for i := uint64(0); i < roundNum; i++ {
 			timeout = timeout * 2
 			if timeout > maxRequestTimeout {
 				timeout = maxRequestTimeout
@@ -365,18 +382,17 @@ func (c *Core) newRoundChangeTimer() {
 		}
 		// prevent log storm when unexpected overflow happens
 		if timeout < baseTimeout {
-			c.currentLogger(true, nil).Warn("WBFT: Possible request timeout overflow detected, setting timeout value to maxRequestTimeout",
+			logger.Warn("WBFT: Possible request timeout overflow detected, setting timeout value to maxRequestTimeout",
 				"timeout", timeout.Seconds(),
 				"max_request_timeout", maxRequestTimeout.Seconds(),
 			)
 			timeout = maxRequestTimeout
 		}
 	} else {
-		timeoutFloat64 := math.Pow(2, float64(round)) * float64(baseTimeout)
+		timeoutFloat64 := math.Pow(2, float64(roundNum)) * float64(baseTimeout)
 
 		if math.IsNaN(timeoutFloat64) || math.IsInf(timeoutFloat64, 0) || timeoutFloat64 > float64(math.MaxInt64) {
-			c.currentLogger(true, nil).Warn("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
-				"round", round,
+			logger.Warn("WBFT: Timeout overflow detected, setting timeout value to MaxInt64",
 				"adjusted_timeout", time.Duration(math.MaxInt64).Seconds(),
 			)
 			timeout = time.Duration(math.MaxInt64)
@@ -385,7 +401,7 @@ func (c *Core) newRoundChangeTimer() {
 		}
 	}
 
-	c.currentLogger(true, nil).Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
+	logger.Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
 	c.timerMu.Lock()
 	canceled := new(bool)
 	c.lastSentTimeoutCanceled = canceled

--- a/consensus/wbft/core/core.go
+++ b/consensus/wbft/core/core.go
@@ -387,10 +387,10 @@ func (c *Core) newRoundChangeTimer() {
 
 	c.currentLogger(true, nil).Trace("WBFT: start new ROUND-CHANGE timer", "timeout", timeout.Seconds())
 	c.timerMu.Lock()
-	c.lastSentTimeoutCanceled = new(bool)
-	*c.lastSentTimeoutCanceled = false
+	canceled := new(bool)
+	c.lastSentTimeoutCanceled = canceled
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
-		c.sendEvent(timeoutEvent{c.lastSentTimeoutCanceled})
+		c.sendEvent(timeoutEvent{canceled})
 	})
 	c.timerMu.Unlock()
 }

--- a/consensus/wbft/core/extraseal.go
+++ b/consensus/wbft/core/extraseal.go
@@ -136,6 +136,7 @@ func (c *Core) ProcessExtraSeal(lastProposal wbft.Proposal, priorRound *big.Int,
 
 	preparedSeal := make([]wbft.SealData, 0)
 	committedSeal := make([]wbft.SealData, 0)
+
 	// latestView is view to process extra seal
 	latestView := wbft.View{
 		Round:    priorRound,

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -144,6 +144,7 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 			logger.Info("WBFT: PRE-PREPARE block proposal is in the future (will be treated again later)", "duration", duration)
 
 			// start a timer to re-input PRE-PREPARE message as a backlog event
+			c.timerMu.Lock()
 			c.stopFuturePreprepareTimer()
 			c.futurePreprepareTimer = time.AfterFunc(duration, func() {
 				_, validator := c.valSet.GetByAddress(preprepare.Source())
@@ -152,6 +153,7 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 					msg: preprepare,
 				})
 			})
+			c.timerMu.Unlock()
 		} else {
 			logger.Warn("WBFT: invalid PRE-PREPARE block proposal", "err", err)
 		}

--- a/consensus/wbft/core/preprepare.go
+++ b/consensus/wbft/core/preprepare.go
@@ -21,6 +21,7 @@
 package core
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -165,8 +166,17 @@ func (c *Core) handlePreprepareMsg(preprepare *wbfmessage.Preprepare) error {
 	if c.state == StateAcceptRequest {
 		c.logger.Debug("WBFT: accepted PRE-PREPARE message")
 
-		// Re-initialize ROUND-CHANGE timer
-		c.newRoundChangeTimer()
+		// Re-initialize ROUND-CHANGE timer.
+		// Snapshot the current view under RLock; newRoundChangeTimer no longer
+		// reads c.current and relies solely on the passed-in values.
+		var seq, round *big.Int
+		c.currentMutex.RLock()
+		if c.current != nil {
+			seq = new(big.Int).Set(c.current.Sequence())
+			round = new(big.Int).Set(c.current.Round())
+		}
+		c.currentMutex.RUnlock()
+		c.newRoundChangeTimer(seq, round)
 		c.consensusTimestamp = time.Now()
 
 		// Update current state

--- a/consensus/wbft/core/request.go
+++ b/consensus/wbft/core/request.go
@@ -64,6 +64,7 @@ func (c *Core) checkRequestMsg(request *Request) error {
 	if request == nil || request.Proposal == nil {
 		return errInvalidMessage
 	}
+
 	if c.current == nil {
 		return errCurrentIsNil
 	}

--- a/consensus/wbft/core/roundstate.go
+++ b/consensus/wbft/core/roundstate.go
@@ -110,6 +110,7 @@ func (s *roundState) SetRound(r *big.Int) {
 	s.round = new(big.Int).Set(r)
 }
 
+// Returned *big.Int must be treated read-only; never mutate it
 func (s *roundState) Round() *big.Int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -121,9 +122,10 @@ func (s *roundState) SetSequence(seq *big.Int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.sequence = seq
+	s.sequence = new(big.Int).Set(seq)
 }
 
+// Returned *big.Int must be treated read-only; never mutate it
 func (s *roundState) Sequence() *big.Int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
### Summary

This PR fixes data races in the WBFT consensus engine identified by the Go race detector (`-race`), focusing on production runtime concurrency issues.

### Problem

The Go race detector reported the following concurrent read/write conflicts at runtime:

**`stopTimer()` concurrent calls** (`core.go`): The consensus event loop goroutine and `Core.Stop()` goroutine called `stopTimer()` simultaneously, causing a race on timer fields (`roundChangeTimer`, `lastSentTimeoutCanceled`, `futurePreprepareTimer`).

**`newRoundChangeTimer()` unsynchronized reads of `c.current`** (`core.go`, `preprepare.go`): During node startup, `startNewRound()` runs on the `Start()` goroutine while `handleEvents()` may concurrently receive a PRE-PREPARE message and invoke `newRoundChangeTimer()` through `handlePreprepareMsg()`. The function previously read `c.current` (nil-wait loop, `Sequence()`, `Round()`) without holding `currentMutex`, creating an unsynchronized read/write that the race detector flags and that can produce an incorrect timer duration.

### Changes

#### `consensus/wbft/core/core.go`
- **Add `timerMu sync.Mutex`**: Protects concurrent access to timer fields (`roundChangeTimer`, `lastSentTimeoutCanceled`, `futurePreprepareTimer`) accessed simultaneously from the consensus event loop and `Core.Stop()`.
- **`currentMutex sync.Mutex` → `sync.RWMutex`**: Allows safe concurrent reads of current round state; only mutating paths take a write lock.
- **`newRoundChangeTimer()` signature change to `newRoundChangeTimer(seq, round *big.Int)`**: Eliminates unsynchronized reads of `c.current` inside the function. Callers are required to snapshot `seq` and `round` under `currentMutex` before calling. `startNewRound()` passes values directly since it already holds `Lock()`; `handlePreprepareMsg()` snapshots under `RLock()` and releases before the call. Mirrors the existing snapshot contract of `newRetrySendingRoundChangeTimer`.

#### `consensus/wbft/core/preprepare.go`
- **Snapshot `c.current` under `currentMutex.RLock()` before calling `newRoundChangeTimer`**: Synchronizes the read of `c.current.Sequence()` and `c.current.Round()` against concurrent writes in `startNewRound()`. The lock is released before the call to avoid a potential deadlock with the write lock held by `startNewRound()`.