### PR TITLE
fix(wbft): prevent drop of valid next-sequence messages in future-view check

### DIFF
--- a/consensus/wbft/core/backlog.go
+++ b/consensus/wbft/core/backlog.go
@@ -49,13 +49,13 @@ const (
 // isSequenceTooFarAhead returns true if the sequence difference exceeds the threshold
 func (c *Core) isSequenceTooFarAhead(viewSeq, currSeq *big.Int, threshold int64) (*big.Int, bool) {
 	seqDiff := new(big.Int).Sub(viewSeq, currSeq)
-	return seqDiff, seqDiff.Cmp(big.NewInt(threshold)) >= 0
+	return seqDiff, seqDiff.Cmp(big.NewInt(threshold)) > 0
 }
 
 // isRoundTooFarAhead returns true if the round difference exceeds the threshold
 func (c *Core) isRoundTooFarAhead(viewRound, currRound *big.Int, threshold int64) (*big.Int, bool) {
 	roundDiff := new(big.Int).Sub(viewRound, currRound)
-	return roundDiff, roundDiff.Cmp(big.NewInt(threshold)) >= 0
+	return roundDiff, roundDiff.Cmp(big.NewInt(threshold)) > 0
 }
 
 // isTooFarFutureMessage filters out messages too far ahead in sequence or round

--- a/consensus/wbft/core/backlog_test.go
+++ b/consensus/wbft/core/backlog_test.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestIsSequenceTooFarAhead(t *testing.T) {
+	c := &Core{}
+	threshold := int64(1)
+
+	tests := []struct {
+		viewSeq  int64
+		currSeq  int64
+		expected bool
+	}{
+		{100, 100, false}, // same
+		{101, 100, false}, // next (diff=1) - SHOULD NOT BE TOO FAR
+		{102, 100, true},  // diff=2 - TOO FAR
+	}
+
+	for _, tt := range tests {
+		_, tooFar := c.isSequenceTooFarAhead(big.NewInt(tt.viewSeq), big.NewInt(tt.currSeq), threshold)
+		if tooFar != tt.expected {
+			t.Errorf("isSequenceTooFarAhead(%d, %d, %d) = %v; want %v", tt.viewSeq, tt.currSeq, threshold, tooFar, tt.expected)
+		}
+	}
+}
+
+func TestIsRoundTooFarAhead(t *testing.T) {
+	c := &Core{}
+	threshold := int64(10)
+
+	tests := []struct {
+		viewRound int64
+		currRound int64
+		expected  bool
+	}{
+		{0, 0, false},
+		{5, 0, false},
+		{10, 0, false}, // diff=10 - SHOULD NOT BE TOO FAR
+		{11, 0, true},  // diff=11 - TOO FAR
+	}
+
+	for _, tt := range tests {
+		_, tooFar := c.isRoundTooFarAhead(big.NewInt(tt.viewRound), big.NewInt(tt.currRound), threshold)
+		if tooFar != tt.expected {
+			t.Errorf("isRoundTooFarAhead(%d, %d, %d) = %v; want %v", tt.viewRound, tt.currRound, threshold, tooFar, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Modified the inverse of `isSequenceTooFarAhead`/`isRoundTooFarAhead` from `>=` to `>`
- "Allows up to 1 future sequence" / "Allows up to 10 future rounds"
- Fixed the issue where `diff = Threshold` was causing `errFutureViewTooFar` to fail due to Off-by-one, resulting in the view not being added to the backlog and being dropped.

## Background

Under certain validator arrangements (e.g., 5 of 7 validators blacklisted in a consecutive pattern), consensus was observed to fail at Round 0 even when a legitimate, non-blacklisted proposer broadcast a valid PRE-PREPARE. The block then fell through Rounds 1–5 (all blacklisted proposers, rejected), and was finally committed at Round 6.
  

## Changes

`consensus/wbft/core/backlog.go`:

  - `isSequenceTooFarAhead`: change `seqDiff.Cmp(threshold) >= 0` → `> 0`
  - `isRoundTooFarAhead`: same pattern, `roundDiff.Cmp(threshold) >= 0` → `> 0`

  Both comparisons now match, so a message exactly at the threshold is classified as a normal future message (`errFutureMessage`) and stored in the backlog. 

## Test Plan

  - Added `TestIsSequenceTooFarAhead` and `TestIsRoundTooFarAhead` in `consensus/wbft/core/backlog_test.go` covering the boundary cases:
    - Sequence: `diff = 0 / 1 / 2` with `threshold = 1`
    - Round: `diff = 0 / 5 / 10 / 11` with `threshold = 10`

- Both tests assert `diff == threshold` returns `false` (not too far), which would have failed under the old `>=` comparison and passes after the fix.
