### PR TITLE
fix: VerifyHeaders for mixed header batch at Croissant fork boundary

### DIFF
--- a/consensus/wbft/backend/engine.go
+++ b/consensus/wbft/backend/engine.go
@@ -85,6 +85,21 @@ func (sb *Backend) verifyHeader(chain consensus.ChainHeaderReader, header *types
 // a results channel to retrieve the async verifications (the order is that of
 // the input slice).
 func (sb *Backend) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header) (chan<- struct{}, <-chan error) {
+	return sb.verifyHeaders(chain, headers, nil)
+}
+
+// VerifyHeadersWithParent is like VerifyHeaders but accepts an explicit parent
+// header as the parent of headers[0]. Use this when the immediate parent of the
+// first header in the batch is not yet in the chain DB (e.g. snap sync batches
+// that start at the Croissant fork boundary).
+func (sb *Backend) VerifyHeadersWithParent(chain consensus.ChainHeaderReader, headers []*types.Header, parent *types.Header) (chan<- struct{}, <-chan error) {
+	return sb.verifyHeaders(chain, headers, []*types.Header{parent})
+}
+
+// verifyHeaders is the shared implementation for VerifyHeaders and
+// VerifyHeadersWithParent. seed is used as parents for headers[0]; nil means
+// the first header has no in-memory parents and falls back to chain DB lookup.
+func (sb *Backend) verifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seed []*types.Header) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 	go func() {
@@ -94,13 +109,17 @@ func (sb *Backend) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*t
 			if errored {
 				err = consensus.ErrUnknownAncestor
 			} else {
-				err = sb.verifyHeader(chain, header, headers[:i])
+				var parents []*types.Header
+				if i == 0 {
+					parents = seed
+				} else {
+					parents = headers[:i]
+				}
+				err = sb.verifyHeader(chain, header, parents)
 			}
-
 			if err != nil {
 				errored = true
 			}
-
 			select {
 			case <-abort:
 				return

--- a/consensus/wemix/consensus.go
+++ b/consensus/wemix/consensus.go
@@ -79,6 +79,9 @@ func (we *CroissantConsensus) VerifyHeader(chain consensus.ChainHeaderReader, he
 	return we.legacy.VerifyHeader(chain, header)
 }
 
+// VerifyHeaders verifies a batch of headers. If the batch spans the Croissant
+// fork boundary, it splits the headers into legacy and wbft slices and verifies
+// each with the appropriate engine sequentially.
 func (we *CroissantConsensus) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header) (chan<- struct{}, <-chan error) {
 	if chain.Config().IsCroissant(headers[0].Number) {
 		return we.wbft.VerifyHeaders(chain, headers)
@@ -86,29 +89,46 @@ func (we *CroissantConsensus) VerifyHeaders(chain consensus.ChainHeaderReader, h
 		return we.legacy.VerifyHeaders(chain, headers)
 	}
 
+	// Mixed batch spanning the Croissant fork boundary.
+	// Split into legacy and wbft slices so each engine can do batch verification
+	// (which passes preceding headers as parents), avoiding ErrUnknownAncestor
+	// that would occur if each header were verified individually via VerifyHeader.
+	croissantBlock := chain.Config().CroissantBlock
+	splitIdx := int(new(big.Int).Sub(croissantBlock, headers[0].Number).Int64())
+
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
+
 	go func() {
-		errored := false
-		for _, header := range headers {
-			var err error
-			if errored {
-				err = consensus.ErrUnknownAncestor
-			} else {
-				err = we.VerifyHeader(chain, header)
-			}
-
-			if err != nil {
-				errored = true
-			}
-
+		// Verify legacy headers first. Sequential execution ensures results are
+		// forwarded in order and the last legacy header is available as the parent
+		// seed for the wbft batch below.
+		legacyAbort, legacyResults := we.legacy.VerifyHeaders(chain, headers[:splitIdx])
+		defer close(legacyAbort) // propagate abort to sub-engine goroutine on exit
+		for i := 0; i < splitIdx; i++ {
 			select {
 			case <-abort:
 				return
-			case results <- err:
+			case err := <-legacyResults:
+				results <- err
+			}
+		}
+
+		// Verify wbft headers with the last legacy header injected as the explicit
+		// parent of headers[0], since it is not yet committed to the chain DB
+		// during snap sync.
+		wbftAbort, wbftResults := we.wbft.VerifyHeadersWithParent(chain, headers[splitIdx:], headers[splitIdx-1])
+		defer close(wbftAbort) // propagate abort to sub-engine goroutine on exit
+		for i := splitIdx; i < len(headers); i++ {
+			select {
+			case <-abort:
+				return
+			case err := <-wbftResults:
+				results <- err
 			}
 		}
 	}()
+
 	return abort, results
 }
 


### PR DESCRIPTION
## Background

`VerifyHeaders` in each engine passes `headers[:i]` as in-memory parents when verifying each header in a batch. When a batch spans the Croissant fork boundary, the previous implementation fell into the mixed-batch path and called `VerifyHeader` individually for each header, providing no in-memory parents. As a result, `verifyCascadingFields` and `GetValidatorsForVerifying` fell back to `chain.GetHeader` for parent lookup. During snap sync, headers in the current batch are not yet committed to the chain DB, so every wbft header in a mixed batch failed with `ErrUnknownAncestor`.

## Solution

Split mixed batches at the Croissant boundary into legacy and wbft slices, and verify each slice with the appropriate engine as a batch. This restores the `headers[:i]` in-memory parent chain within each slice, eliminating chain DB fallback for headers in the current batch.

Since the wbft slice starts at the Croissant block, its first header's parent (the last legacy header) falls outside the slice and still requires a chain DB lookup. To address this, `VerifyHeadersWithParent` is added to the wbft backend to accept an explicit parent for `headers[0]`, used as the in-memory parent seed instead of falling back to the chain DB.

## Changes

`consensus/wemix/consensus.go`
- Split mixed batches at the Croissant boundary and verify each slice with the appropriate engine sequentially
- Pass the last legacy header as an explicit parent seed via `VerifyHeadersWithParent` for the wbft slice

`consensus/wbft/backend/engine.go`
- Add `VerifyHeadersWithParent(chain, headers, parent)` to accept an explicit parent for `headers[0]`
- Refactor `VerifyHeaders` and `VerifyHeadersWithParent` to share a common internal `verifyHeaders` implementation
