### PR TITLE
fix(txpool): restore cumulative overdraft check for fee delegation txs

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -129,3 +129,10 @@ var (
 	ErrAuthorizationDestinationHasCode = errors.New("EIP-7702 authorization destination is a contract")
 	ErrAuthorizationNonceMismatch      = errors.New("EIP-7702 authorization nonce does not match current account nonce")
 )
+
+// Internal invariant errors. These indicate bugs in the node's bookkeeping
+// rather than invalid user input, and should be treated as such by callers
+// (e.g. surfaced loudly rather than counted as ordinary validation failures).
+var (
+	ErrTxPoolAccountingUnderflow = errors.New("txpool accounting underflow")
+)

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1052,7 +1052,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 42200 wei spent: reject nonce 2 with 21100 wei spend (1 wei overflow)
 					from: "alice",
 					tx:   makeUnsignedTx(2, 1, 1, 1),
-					err:  nil, // core.ErrInsufficientFunds; WEMIX does not return error; please refer validation.go:251
+					err:  core.ErrInsufficientFunds,
 				},
 			},
 		},
@@ -1181,7 +1181,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 325344 wei spent: reject nonce 0 with 599684 wei spend (173072 extra) (would overflow balance at nonce 1)
 					from: "alice",
 					tx:   makeUnsignedTx(0, 2, 5, 2),
-					err:  nil, //core.ErrInsufficientFunds,; WEMIX does not return error
+					err:  core.ErrInsufficientFunds,
 				},
 				{ // New account, 2 pooled tx with 325344 wei spent: reject nonce 0 with no-gastip-bump
 					from: "alice",
@@ -1201,7 +1201,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 325344 wei spent: accept nonce 0 with 84100 wei spend (42000 extra)
 					from: "alice",
 					tx:   makeUnsignedTx(0, 2, 4, 2),
-					err:  txpool.ErrReplaceUnderpriced,
+					err:  nil,
 				},
 			},
 		},

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -692,10 +692,16 @@ func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int
 	}
 }
 
-// validateTx checks whether a transaction is valid according to the consensus
-// rules and adheres to some heuristic limits of the local node (price and size).
-func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
-	opts := &txpool.ValidationOptionsWithState{
+// stateValidationOptions builds the stateful validation options (nonce, balance
+// and cumulative overdraft checks) used by ValidateTransactionWithState. The same
+// option set is reused on submission (validateTx) and on promotion of queued
+// transactions, so the cumulative affordability check stays identical across both
+// paths. The callbacks read pool.pending / pool.pendingGas live, so when the
+// options are reused while promoting a batch, each freshly promoted transaction's
+// obligation is reflected in the next transaction's check.
+// Note, this method assumes the pool lock is held!
+func (pool *LegacyPool) stateValidationOptions() *txpool.ValidationOptionsWithState {
+	return &txpool.ValidationOptionsWithState{
 		State: pool.currentState,
 
 		FirstNonceGap:    nil, // Pool allows arbitrary arrival order, don't invalidate nonce gaps
@@ -731,7 +737,12 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 			return nil
 		},
 	}
-	if err := txpool.ValidateTransactionWithState(tx, pool.signer, opts); err != nil {
+}
+
+// validateTx checks whether a transaction is valid according to the consensus
+// rules and adheres to some heuristic limits of the local node (price and size).
+func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
+	if err := txpool.ValidateTransactionWithState(tx, pool.signer, pool.stateValidationOptions()); err != nil {
 		return err
 	}
 	return pool.validateAuth(tx)
@@ -1613,8 +1624,12 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 			pool.all.Remove(hash)
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
-		// Drop all transactions that are too costly (low balance or out of gas)
-		drops, _ := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
+		// Drop all transactions that are too costly (low balance or out of gas).
+		// enforceFeePayer is false here: a queued fee-delegated tx whose fee payer
+		// is only temporarily insolvent is left queued (and retried on a later
+		// pass) instead of being dropped. The promotion loop below still rejects it
+		// via ValidateTransactionWithState until the fee payer can afford it.
+		drops, _ := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), false, pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
@@ -1622,16 +1637,43 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		log.Trace("Removed unpayable queued transactions", "count", len(drops))
 		queuedNofundsMeter.Mark(int64(len(drops)))
 
-		// Gather all executable transactions and promote them
-		readies := list.Ready(pool.pendingNonces.get(addr))
+		// Peek the executable prefix without removing it, then admit only the
+		// transactions that pass. For fee-delegated transactions the shared fee
+		// payer may be over-committed once several senders' queues are promoted in
+		// the same pass, so run ValidateTransactionWithState (cumulative check)
+		// before each admit. On the first failure we stop: that transaction and
+		// every later one depend on it by nonce, so they stay queued (Peek-then-
+		// Admit) and are retried on a later pass once the fee payer can afford
+		// them. Plain transactions keep the existing per-tx behaviour.
+		readies := list.PeekReady(pool.pendingNonces.get(addr))
+		var (
+			admitted types.Transactions
+			fdOpts   *txpool.ValidationOptionsWithState // nil until the first FD tx; reused for subsequent ones
+		)
 		for _, tx := range readies {
-			hash := tx.Hash()
-			if pool.promoteTx(addr, hash, tx) {
+			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+				if fdOpts == nil {
+					fdOpts = pool.stateValidationOptions()
+				}
+				if err := txpool.ValidateTransactionWithState(tx, pool.signer, fdOpts); err != nil {
+					break // failing tx and its tail stay queued (nonce dependency)
+				}
+			}
+			if pool.promoteTx(addr, tx.Hash(), tx) {
 				promoted = append(promoted, tx)
+				admitted = append(admitted, tx)
+			} else {
+				// promoteTx already cleaned pool.all/priced; drop it from the
+				// queue and stop, since the tail depends on this nonce.
+				admitted = append(admitted, tx)
+				break
 			}
 		}
-		log.Trace("Promoted queued transactions", "count", len(promoted))
-		queuedGauge.Dec(int64(len(readies)))
+		// PeekReady did not remove anything; remove only the admitted prefix so the
+		// rejected tail remains in the queue.
+		list.RemoveReadyPrefix(admitted)
+		log.Trace("Promoted queued transactions", "count", len(admitted))
+		queuedGauge.Dec(int64(len(admitted)))
 
 		// Drop all transactions over the allowed limit
 		var caps types.Transactions
@@ -1815,7 +1857,9 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		drops, invalids := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
+		// enforceFeePayer is true here: pending txs must stay payable, so a
+		// fee-delegated tx whose fee payer can no longer afford the gas is dropped.
+		drops, invalids := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), true, pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -670,7 +670,7 @@ func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int
 func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int) {
 	acc := pool.pendingGas[payer]
 	if acc == nil {
-		panic("pendingGas underflow")
+		panic("pendingGas: no entry for payer")
 	}
 	if _, underflow := acc.SubOverflow(acc, feeCost); underflow {
 		panic("pendingGas underflow")

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1029,16 +1029,23 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 	}
 }
 
+func newPendingList(add, sub func(common.Address, *uint256.Int)) *list {
+	if add == nil || sub == nil {
+		panic("legacypool: pending list requires both gas accounting callbacks")
+	}
+	l := newList(true)
+	l.addPendingGas = add
+	l.subPendingGas = sub
+	return l
+}
+
 // promoteTx adds a transaction to the pending (processable) list of transactions
 // and returns whether it was inserted or an older was better.
 // Note, this method assumes the pool lock is held!
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		list := newList(true)
-		list.addPendingGas = pool.addPendingGas
-		list.subPendingGas = pool.subPendingGas
-		pool.pending[addr] = list
+		pool.pending[addr] = newPendingList(pool.addPendingGas, pool.subPendingGas)
 	}
 	list := pool.pending[addr]
 

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -250,7 +250,7 @@ type LegacyPool struct {
 	reserver   txpool.Reserver                 // Address reserver to ensure exclusivity across subpools
 	pending    map[common.Address]*list        // All currently processable transactions
 	queue      map[common.Address]*list        // Queued but non-processable transactions
-	pendingGas map[common.Address]*uint256.Int // Cumulative pending gas fee indexed by gas payer (sender, or fee payer for delegation txs)
+	pendingGas map[common.Address]*uint256.Int // Cumulative pending gas fee indexed by fee payer for fee-delegated txs
 	beats      map[common.Address]time.Time    // Last heartbeat from each known account
 	all        *lookup                         // All transactions to allow lookups
 	priced     *pricedList                     // All transactions sorted by price

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -904,7 +904,11 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 	// Try to replace an existing transaction in the pending pool
 	if list := pool.pending[from]; list != nil && list.Contains(tx.Nonce()) {
 		// Nonce already pending, check if required price bump is met
-		inserted, old := list.Add(tx, pool.config.PriceBump)
+		inserted, old, err := list.Add(tx, pool.config.PriceBump)
+		if err != nil {
+			pendingDiscardMeter.Mark(1)
+			return false, err
+		}
 		if !inserted {
 			pendingDiscardMeter.Mark(1)
 			return false, txpool.ErrReplaceUnderpriced
@@ -978,7 +982,11 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, local
 	if pool.queue[from] == nil {
 		pool.queue[from] = newList(false)
 	}
-	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump)
+	inserted, old, err := pool.queue[from].Add(tx, pool.config.PriceBump)
+	if err != nil {
+		queuedDiscardMeter.Mark(1)
+		return false, err
+	}
 	if !inserted {
 		// An older transaction was better, discard this
 		queuedDiscardMeter.Mark(1)
@@ -1034,7 +1042,11 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 	}
 	list := pool.pending[addr]
 
-	inserted, old := list.Add(tx, pool.config.PriceBump)
+	inserted, old, err := list.Add(tx, pool.config.PriceBump)
+	if err != nil {
+		log.Error("legacypool: promoteTx encountered invalid tx in queue",
+			"tx", tx.Hash(), "err", err)
+	}
 	if !inserted {
 		// An older transaction was better, discard this
 		pool.all.Remove(hash)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -658,6 +658,28 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 	return nil
 }
 
+func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int) {
+	acc := pool.pendingGas[payer]
+	if acc == nil {
+		acc = new(uint256.Int)
+		pool.pendingGas[payer] = acc
+	}
+	acc.Add(acc, feeCost)
+}
+
+func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int) {
+	acc := pool.pendingGas[payer]
+	if acc == nil {
+		panic("pendingGas underflow")
+	}
+	if _, underflow := acc.SubOverflow(acc, feeCost); underflow {
+		panic("pendingGas underflow")
+	}
+	if acc.IsZero() {
+		delete(pool.pendingGas, payer)
+	}
+}
+
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
@@ -1001,16 +1023,13 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 
 // promoteTx adds a transaction to the pending (processable) list of transactions
 // and returns whether it was inserted or an older was better.
-//
 // Note, this method assumes the pool lock is held!
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
 		list := newList(true)
-		// Share the pool-wide fee-payer gas index by reference so this sender's
-		// fee-delegated txs contribute to their fee payer's cumulative obligation.
-		// Only pending lists are wired up (the overdraft check is pending-only).
-		list.pendingGas = pool.pendingGas
+		list.addPendingGas = pool.addPendingGas
+		list.subPendingGas = pool.subPendingGas
 		pool.pending[addr] = list
 	}
 	list := pool.pending[addr]

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -707,17 +707,13 @@ func (pool *LegacyPool) stateValidationOptions() *txpool.ValidationOptionsWithSt
 		FirstNonceGap:    nil, // Pool allows arbitrary arrival order, don't invalidate nonce gaps
 		UsedAndLeftSlots: nil, // Pool has own mechanism to limit the number of transactions
 		ExistingExpenditure: func(addr common.Address) *big.Int {
-			// Total wei the account is on the hook for in the pending set (matching
-			// upstream's pending-only accounting): value it owes as a sender, gas it
-			// owes as its own gas payer, and gas it owes as a fee payer for others.
-			// Queued (non-executable) txs are not counted; they are re-checked on
-			// promotion.
 			obligation := new(big.Int)
 			if list := pool.pending[addr]; list != nil {
-				obligation.Add(obligation, list.totalvalue.ToBig())
-				obligation.Add(obligation, list.totalgas.ToBig())
+				// Sender-paid pending costs for txs sent by this account.
+				obligation.Add(obligation, list.totalcost.ToBig())
 			}
 			if g := pool.pendingGas[addr]; g != nil {
+				// Fee-delegated gas charged to this account as fee payer.
 				obligation.Add(obligation, g.ToBig())
 			}
 			return obligation
@@ -932,7 +928,6 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 			pendingDiscardMeter.Mark(1)
 			return false, err
 		}
-
 		// New transaction is better, replace old one
 		if old != nil {
 			pool.all.Remove(old.Hash())
@@ -1007,7 +1002,6 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, local
 		queuedDiscardMeter.Mark(1)
 		return false, err
 	}
-
 	// Discard any previous transaction and mark this
 	if old != nil {
 		pool.all.Remove(old.Hash())

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -660,10 +660,6 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 
 func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int) {
 	if feeCost.IsZero() {
-		// A zero gas obligation contributes nothing; do not create a map entry.
-		// subPendingGas mirrors this (it deletes entries that reach zero and panics
-		// on a missing one), so a zero contribution must be skipped on both sides to
-		// keep the accounting symmetric.
 		return
 	}
 	acc := pool.pendingGas[payer]
@@ -676,8 +672,6 @@ func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int
 
 func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int) {
 	if feeCost.IsZero() {
-		// Mirror addPendingGas: a zero contribution was never recorded, so there is
-		// nothing to reverse (and the entry may legitimately not exist).
 		return
 	}
 	acc := pool.pendingGas[payer]
@@ -692,14 +686,11 @@ func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int
 	}
 }
 
-// stateValidationOptions builds the stateful validation options (nonce, balance
-// and cumulative overdraft checks) used by ValidateTransactionWithState. The same
-// option set is reused on submission (validateTx) and on promotion of queued
-// transactions, so the cumulative affordability check stays identical across both
-// paths. The callbacks read pool.pending / pool.pendingGas live, so when the
-// options are reused while promoting a batch, each freshly promoted transaction's
-// obligation is reflected in the next transaction's check.
-// Note, this method assumes the pool lock is held!
+// stateValidationOptions builds the stateful validation options used by
+// ValidateTransactionWithState. Both submission and queued promotion use this
+// builder so nonce, balance, and cumulative overdraft checks stay identical.
+// The expenditure callbacks read pending state at call time, so promotion
+// reflects txs admitted earlier in the same batch. The pool lock must be held.
 func (pool *LegacyPool) stateValidationOptions() *txpool.ValidationOptionsWithState {
 	return &txpool.ValidationOptionsWithState{
 		State: pool.currentState,
@@ -1618,12 +1609,8 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 			pool.all.Remove(hash)
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
-		// Drop all transactions that are too costly (low balance or out of gas).
-		// enforceFeePayer is false here: a queued fee-delegated tx whose fee payer
-		// is only temporarily insolvent is left queued (and retried on a later
-		// pass) instead of being dropped. The promotion loop below still rejects it
-		// via ValidateTransactionWithState until the fee payer can afford it.
-		drops, _ := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), false, pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
+		// Drop queued txs that fail per-tx affordability or block gas checks.
+		drops, _ := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
@@ -1631,43 +1618,52 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		log.Trace("Removed unpayable queued transactions", "count", len(drops))
 		queuedNofundsMeter.Mark(int64(len(drops)))
 
-		// Peek the executable prefix without removing it, then admit only the
-		// transactions that pass. For fee-delegated transactions the shared fee
-		// payer may be over-committed once several senders' queues are promoted in
-		// the same pass, so run ValidateTransactionWithState (cumulative check)
-		// before each admit. On the first failure we stop: that transaction and
-		// every later one depend on it by nonce, so they stay queued (Peek-then-
-		// Admit) and are retried on a later pass once the fee payer can afford
-		// them. Plain transactions keep the existing per-tx behaviour.
-		readies := list.PeekReady(pool.pendingNonces.get(addr))
+		// Gather all executable transactions and promote them. Fee-delegated txs
+		// are re-checked against the shared fee payer's cumulative budget; on the
+		// first failure that tx and its nonce tail are unpromotable, so they are
+		// dropped from the pool (Drop & Forget). Plain txs keep the per-tx behaviour.
+		readies := list.Ready(pool.pendingNonces.get(addr))
+		before := len(promoted) // promoted is the outer-loop accumulator
 		var (
-			admitted types.Transactions
-			fdOpts   *txpool.ValidationOptionsWithState // nil until the first FD tx; reused for subsequent ones
+			rejectedAtPromote types.Transactions
+			fdOpts            *txpool.ValidationOptionsWithState
 		)
-		for _, tx := range readies {
+		for i, tx := range readies {
 			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
 				if fdOpts == nil {
 					fdOpts = pool.stateValidationOptions()
 				}
 				if err := txpool.ValidateTransactionWithState(tx, pool.signer, fdOpts); err != nil {
-					break // failing tx and its tail stay queued (nonce dependency)
+					rejectedAtPromote = append(rejectedAtPromote, readies[i:]...)
+					break
 				}
 			}
 			if pool.promoteTx(addr, tx.Hash(), tx) {
 				promoted = append(promoted, tx)
-				admitted = append(admitted, tx)
 			} else {
-				// promoteTx already cleaned pool.all/priced; drop it from the
-				// queue and stop, since the tail depends on this nonce.
-				admitted = append(admitted, tx)
+				// promoteTx already removed tx from the global indexes. Ready removed the
+				// whole prefix from the queue, so only the unprocessed nonce tail needs cleanup.
+				rejectedAtPromote = append(rejectedAtPromote, readies[i+1:]...)
 				break
 			}
 		}
-		// PeekReady did not remove anything; remove only the admitted prefix so the
-		// rejected tail remains in the queue.
-		list.RemoveReadyPrefix(admitted)
-		log.Trace("Promoted queued transactions", "count", len(admitted))
-		queuedGauge.Dec(int64(len(admitted)))
+		log.Trace("Promoted queued transactions", "count", len(promoted)-before)
+		queuedGauge.Dec(int64(len(readies)))
+
+		// Drop the rejected tail. list.Ready already removed them from the queue
+		// list and reversed their cost accounting (subCosts), and queuedGauge was
+		// decremented above via len(readies); only the global lookup, priced index,
+		// and local gauge remain to clean up.
+		for _, tx := range rejectedAtPromote {
+			pool.all.Remove(tx.Hash())
+		}
+		if n := len(rejectedAtPromote); n > 0 {
+			pool.priced.Removed(n)
+			queuedNofundsMeter.Mark(int64(n))
+			if pool.locals.contains(addr) {
+				localGauge.Dec(int64(n))
+			}
+		}
 
 		// Drop all transactions over the allowed limit
 		var caps types.Transactions
@@ -1851,9 +1847,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		// enforceFeePayer is true here: pending txs must stay payable, so a
-		// fee-delegated tx whose fee payer can no longer afford the gas is dropped.
-		drops, invalids := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), true, pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
+		drops, invalids := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -659,6 +659,13 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 }
 
 func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int) {
+	if feeCost.IsZero() {
+		// A zero gas obligation contributes nothing; do not create a map entry.
+		// subPendingGas mirrors this (it deletes entries that reach zero and panics
+		// on a missing one), so a zero contribution must be skipped on both sides to
+		// keep the accounting symmetric.
+		return
+	}
 	acc := pool.pendingGas[payer]
 	if acc == nil {
 		acc = new(uint256.Int)
@@ -668,9 +675,14 @@ func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int
 }
 
 func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int) {
+	if feeCost.IsZero() {
+		// Mirror addPendingGas: a zero contribution was never recorded, so there is
+		// nothing to reverse (and the entry may legitimately not exist).
+		return
+	}
 	acc := pool.pendingGas[payer]
 	if acc == nil {
-		panic("pendingGas: no entry for payer")
+		panic("pendingGas no entry for payer")
 	}
 	if _, underflow := acc.SubOverflow(acc, feeCost); underflow {
 		panic("pendingGas underflow")
@@ -904,15 +916,12 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 	// Try to replace an existing transaction in the pending pool
 	if list := pool.pending[from]; list != nil && list.Contains(tx.Nonce()) {
 		// Nonce already pending, check if required price bump is met
-		inserted, old, err := list.Add(tx, pool.config.PriceBump)
+		old, err := list.Add(tx, pool.config.PriceBump)
 		if err != nil {
 			pendingDiscardMeter.Mark(1)
 			return false, err
 		}
-		if !inserted {
-			pendingDiscardMeter.Mark(1)
-			return false, txpool.ErrReplaceUnderpriced
-		}
+
 		// New transaction is better, replace old one
 		if old != nil {
 			pool.all.Remove(old.Hash())
@@ -982,16 +991,12 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, local
 	if pool.queue[from] == nil {
 		pool.queue[from] = newList(false)
 	}
-	inserted, old, err := pool.queue[from].Add(tx, pool.config.PriceBump)
+	old, err := pool.queue[from].Add(tx, pool.config.PriceBump)
 	if err != nil {
 		queuedDiscardMeter.Mark(1)
 		return false, err
 	}
-	if !inserted {
-		// An older transaction was better, discard this
-		queuedDiscardMeter.Mark(1)
-		return false, txpool.ErrReplaceUnderpriced
-	}
+
 	// Discard any previous transaction and mark this
 	if old != nil {
 		pool.all.Remove(old.Hash())
@@ -1049,12 +1054,9 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 	}
 	list := pool.pending[addr]
 
-	inserted, old, err := list.Add(tx, pool.config.PriceBump)
+	old, err := list.Add(tx, pool.config.PriceBump)
 	if err != nil {
 		log.Error("Promoting invalid queued transaction", "hash", tx.Hash(), "err", err)
-	}
-	if !inserted {
-		// An older transaction was better, discard this
 		pool.all.Remove(hash)
 		pool.priced.Removed(1)
 		pendingDiscardMeter.Mark(1)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -247,12 +247,13 @@ type LegacyPool struct {
 	locals  *accountSet // Set of local transaction to exempt from eviction rules
 	journal *journal    // Journal of local transaction to back up to disk
 
-	reserver txpool.Reserver              // Address reserver to ensure exclusivity across subpools
-	pending  map[common.Address]*list     // All currently processable transactions
-	queue    map[common.Address]*list     // Queued but non-processable transactions
-	beats    map[common.Address]time.Time // Last heartbeat from each known account
-	all      *lookup                      // All transactions to allow lookups
-	priced   *pricedList                  // All transactions sorted by price
+	reserver   txpool.Reserver                 // Address reserver to ensure exclusivity across subpools
+	pending    map[common.Address]*list        // All currently processable transactions
+	queue      map[common.Address]*list        // Queued but non-processable transactions
+	pendingGas map[common.Address]*uint256.Int // Cumulative pending gas fee indexed by gas payer (sender, or fee payer for delegation txs)
+	beats      map[common.Address]time.Time    // Last heartbeat from each known account
+	all        *lookup                         // All transactions to allow lookups
+	priced     *pricedList                     // All transactions sorted by price
 
 	reqResetCh      chan *txpoolResetRequest
 	reqPromoteCh    chan *accountSet
@@ -283,6 +284,7 @@ func New(config Config, chain BlockChain) *LegacyPool {
 		signer:          types.LatestSigner(chain.Config()),
 		pending:         make(map[common.Address]*list),
 		queue:           make(map[common.Address]*list),
+		pendingGas:      make(map[common.Address]*uint256.Int),
 		beats:           make(map[common.Address]time.Time),
 		all:             newLookup(),
 		reqResetCh:      make(chan *txpoolResetRequest),
@@ -665,16 +667,32 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 		FirstNonceGap:    nil, // Pool allows arbitrary arrival order, don't invalidate nonce gaps
 		UsedAndLeftSlots: nil, // Pool has own mechanism to limit the number of transactions
 		ExistingExpenditure: func(addr common.Address) *big.Int {
+			// Total wei the account is on the hook for in the pending set (matching
+			// upstream's pending-only accounting): value it owes as a sender, gas it
+			// owes as its own gas payer, and gas it owes as a fee payer for others.
+			// Queued (non-executable) txs are not counted; they are re-checked on
+			// promotion.
+			obligation := new(big.Int)
 			if list := pool.pending[addr]; list != nil {
-				return list.totalcost.ToBig()
+				obligation.Add(obligation, list.totalvalue.ToBig())
+				obligation.Add(obligation, list.totalgas.ToBig())
 			}
-			return new(big.Int)
+			if g := pool.pendingGas[addr]; g != nil {
+				obligation.Add(obligation, g.ToBig())
+			}
+			return obligation
 		},
 		ExistingCost: func(addr common.Address, nonce uint64) *big.Int {
 			if list := pool.pending[addr]; list != nil {
 				if tx := list.txs.Get(nonce); tx != nil {
 					return tx.Cost()
 				}
+			}
+			return nil
+		},
+		ExistingTx: func(addr common.Address, nonce uint64) *types.Transaction {
+			if list := pool.pending[addr]; list != nil {
+				return list.txs.Get(nonce)
 			}
 			return nil
 		},
@@ -988,7 +1006,12 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		pool.pending[addr] = newList(true)
+		list := newList(true)
+		// Share the pool-wide fee-payer gas index by reference so this sender's
+		// fee-delegated txs contribute to their fee payer's cumulative obligation.
+		// Only pending lists are wired up (the overdraft check is pending-only).
+		list.pendingGas = pool.pendingGas
+		pool.pending[addr] = list
 	}
 	list := pool.pending[addr]
 

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1031,7 +1031,7 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 
 func newPendingList(add, sub func(common.Address, *uint256.Int)) *list {
 	if add == nil || sub == nil {
-		panic("legacypool: pending list requires both gas accounting callbacks")
+		panic("pending list requires both gas accounting callbacks")
 	}
 	l := newList(true)
 	l.addPendingGas = add
@@ -1051,8 +1051,7 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 
 	inserted, old, err := list.Add(tx, pool.config.PriceBump)
 	if err != nil {
-		log.Error("legacypool: promoteTx encountered invalid tx in queue",
-			"tx", tx.Hash(), "err", err)
+		log.Error("Promoting invalid queued transaction", "hash", tx.Hash(), "err", err)
 	}
 	if !inserted {
 		// An older transaction was better, discard this

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3393,8 +3393,6 @@ func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
 
 // validateFeeDelegationAccounting recomputes the fee-delegation accounting from
 // the live pending/queue contents and compares it against the maintained values.
-// validatePoolInternals does not cover these, so it cannot catch drift in the
-// per-list feeDelegated counter, totalvalue/totalgas, or the pool-wide pendingGas.
 func validateFeeDelegationAccounting(pool *LegacyPool) error {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
@@ -3416,10 +3414,10 @@ func validateFeeDelegationAccounting(pool *LegacyPool) error {
 		if fd := countFD(l); l.feeDelegated != fd {
 			return fmt.Errorf("pending[%s].feeDelegated = %d, recomputed %d", addr.Hex(), l.feeDelegated, fd)
 		}
-		sumValue, sumGasNonFD := new(big.Int), new(big.Int)
+		sumCost := new(big.Int)
 		for _, tx := range l.txs.items {
-			sumValue.Add(sumValue, tx.Value())
 			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+				sumCost.Add(sumCost, tx.Value())
 				p := *tx.FeePayer()
 				acc := wantPendingGas[p]
 				if acc == nil {
@@ -3428,14 +3426,11 @@ func validateFeeDelegationAccounting(pool *LegacyPool) error {
 				}
 				acc.Add(acc, tx.FeeCost())
 			} else {
-				sumGasNonFD.Add(sumGasNonFD, tx.FeeCost())
+				sumCost.Add(sumCost, tx.Cost())
 			}
 		}
-		if l.totalvalue.ToBig().Cmp(sumValue) != 0 {
-			return fmt.Errorf("pending[%s].totalvalue = %v, recomputed %v", addr.Hex(), l.totalvalue, sumValue)
-		}
-		if l.totalgas.ToBig().Cmp(sumGasNonFD) != 0 {
-			return fmt.Errorf("pending[%s].totalgas = %v, recomputed %v", addr.Hex(), l.totalgas, sumGasNonFD)
+		if l.totalcost.ToBig().Cmp(sumCost) != 0 {
+			return fmt.Errorf("pending[%s].totalcost = %v, recomputed %v", addr.Hex(), l.totalcost, sumCost)
 		}
 	}
 	for addr, l := range pool.queue {

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3138,9 +3138,9 @@ func BenchmarkMultiAccountBatchInsert(b *testing.B) {
 	}
 }
 
-// feeDelegateTx builds a fee delegation dynamic-fee transaction signed by both
-// the sender (over the inner DynamicFeeTx) and the fee payer (over the wrapping
-// FeeDelegateDynamicFeeTx).
+// feeDelegateTx creates a fee-delegated dynamic-fee tx signed by the sender and
+// fee payer. The sender signs the inner DynamicFeeTx; the fee payer signs the
+// outer FeeDelegateDynamicFeeTx.
 func feeDelegateTx(chainID *big.Int, nonce uint64, gas uint64, gasFeeCap, gasTipCap, value *big.Int, senderKey, feePayerKey *ecdsa.PrivateKey) *types.Transaction {
 	to := common.Address{}
 	inner := types.DynamicFeeTx{
@@ -3233,13 +3233,10 @@ func TestFeeDelegationCumulativeGas(t *testing.T) {
 	}
 }
 
-// TestPendingGasZeroAccounting verifies that fee-delegated transactions whose gas
-// obligation is zero (e.g. a zero gas-fee-cap tx) do not corrupt the pool-wide
-// per-fee-payer gas index. addPendingGas creates an entry on first use and
-// subPendingGas deletes it once it reaches zero and panics on a missing one, so a
-// naive implementation would: create a zero entry, delete it on the first
-// removal, then panic on the second removal of another zero-gas tx sharing the
-// fee payer. The accounting must skip zero contributions symmetrically instead.
+// TestPendingGasZeroAccounting verifies that zero gas obligations are ignored
+// symmetrically by pendingGas add/remove accounting, so multiple zero-cost
+// fee-delegated txs sharing a fee payer can be removed without creating stale
+// entries or underflow panics.
 func TestPendingGasZeroAccounting(t *testing.T) {
 	t.Parallel()
 
@@ -3352,31 +3349,23 @@ func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
 	if g := pool.pendingGas[feePayer]; g != nil {
 		gotGas = g.ToBig()
 	}
-	pendingFD, queuedFD := 0, 0
-	for i, tx := range gapTxs {
-		sender := crypto.PubkeyToAddress(senders[i].PublicKey)
-		if pool.all.Get(tx.Hash()) == nil {
-			pool.mu.RUnlock()
-			t.Fatalf("gap tx %d was dropped from pool.all; Peek-then-Admit must retain rejected txs", i)
-		}
-		switch {
-		case pool.pending[sender] != nil && pool.pending[sender].txs.Get(tx.Nonce()) != nil:
-			pendingFD++
-		case pool.queue[sender] != nil && pool.queue[sender].txs.Get(tx.Nonce()) != nil:
-			queuedFD++
-		default:
-			pool.mu.RUnlock()
-			t.Fatalf("gap tx %d is in neither the pending nor the queue list", i)
+	promotedCount, droppedCount := 0, 0
+	for _, tx := range gapTxs {
+		if pool.all.Get(tx.Hash()) != nil {
+			promotedCount++
+		} else {
+			droppedCount++
 		}
 	}
+	if promotedCount != 2 || droppedCount != 1 {
+		t.Fatalf("want 2 promoted and 1 dropped")
+	}
+
 	feePayerBalance := pool.currentState.GetBalance(feePayer).ToBig()
 	pool.mu.RUnlock()
 
 	if want := new(big.Int).Mul(perTxGas, big.NewInt(2)); gotGas.Cmp(want) != 0 {
 		t.Fatalf("pendingGas[feePayer] = %v after promotion, want %v", gotGas, want)
-	}
-	if pendingFD != 2 || queuedFD != 1 {
-		t.Fatalf("fee-delegated txs: %d pending, %d queued, want 2 pending and 1 queued", pendingFD, queuedFD)
 	}
 	// The fee payer's aggregate gas obligation must never exceed its balance.
 	if gotGas.Cmp(feePayerBalance) > 0 {
@@ -3458,52 +3447,6 @@ func validateFeeDelegationAccounting(pool *LegacyPool) error {
 		}
 	}
 	return nil
-}
-
-// TestPeekReadyNonDestructive verifies that list.PeekReady returns the same
-// contiguous run as Ready without removing anything, that it is self-correcting
-// (returns from the heap minimum even when start is higher), and that
-// RemoveReadyPrefix removes only the admitted prefix.
-func TestPeekReadyNonDestructive(t *testing.T) {
-	t.Parallel()
-
-	key, _ := crypto.GenerateKey()
-	l := newList(false)
-	for _, n := range []uint64{0, 1, 2, 4} { // gap at nonce 3
-		l.Add(transaction(n, 0, key), DefaultConfig.PriceBump)
-	}
-
-	// PeekReady returns the contiguous run 0,1,2 (stops at the gap) without removing.
-	ready := l.PeekReady(0)
-	if len(ready) != 3 || ready[0].Nonce() != 0 || ready[1].Nonce() != 1 || ready[2].Nonce() != 2 {
-		t.Fatalf("PeekReady(0) returned wrong run: %v", nonceSlice(ready))
-	}
-	if l.txs.Len() != 4 {
-		t.Fatalf("PeekReady must not remove items: Len = %d, want 4", l.txs.Len())
-	}
-
-	// Self-correcting: even with start beyond the minimum it returns from the heap
-	// minimum (0,1,2), mirroring Ready, so low-nonce txs are never stranded.
-	if got := l.PeekReady(2); len(got) != 3 || got[0].Nonce() != 0 {
-		t.Fatalf("PeekReady(2) = %v, want run starting at heap minimum 0", nonceSlice(got))
-	}
-
-	// Remove only the admitted prefix (0,1); nonces 2 and 4 stay queued.
-	l.RemoveReadyPrefix(ready[:2])
-	if l.txs.Len() != 2 || l.txs.Get(0) != nil || l.txs.Get(1) != nil {
-		t.Fatalf("RemoveReadyPrefix must remove exactly nonces 0,1 (Len=%d)", l.txs.Len())
-	}
-	if l.txs.Get(2) == nil || l.txs.Get(4) == nil {
-		t.Fatalf("RemoveReadyPrefix removed more than the prefix")
-	}
-}
-
-func nonceSlice(txs types.Transactions) []uint64 {
-	out := make([]uint64, len(txs))
-	for i, tx := range txs {
-		out[i] = tx.Nonce()
-	}
-	return out
 }
 
 // TestListFeeDelegatedCounter verifies that the per-list feeDelegated counter is
@@ -3600,74 +3543,6 @@ func TestFeeDelegationFilterShortCircuitGate(t *testing.T) {
 	}
 	if pg != nil && !pg.IsZero() {
 		t.Fatalf("pendingGas[feePayer] = %v after demote, want 0", pg)
-	}
-	if err := validateFeeDelegationAccounting(pool); err != nil {
-		t.Fatalf("fee-delegation accounting drift: %v", err)
-	}
-}
-
-// TestFeeDelegationFeePayerDipRevives verifies the promotion-path liveness goal:
-// a queued fee-delegated tx whose fee payer is only temporarily insolvent is not
-// dropped by the promote-time Filter (enforceFeePayer=false). It stays queued
-// while the fee payer is short, and is promoted automatically once the fee payer
-// can afford it again, without the sender having to resubmit.
-func TestFeeDelegationFeePayerDipRevives(t *testing.T) {
-	t.Parallel()
-
-	config := *params.TestChainConfig
-	config.ApplepieBlock = big.NewInt(0)
-	pool, _ := setupPoolWithConfig(&config)
-	defer pool.Close()
-
-	chainID := config.ChainID
-	const gasLimit = 21000
-	gasFeeCap := big.NewInt(1_000_000_000)
-	gasTipCap := big.NewInt(1)
-	value := big.NewInt(100)
-	feeCost := new(big.Int).Mul(big.NewInt(gasLimit), gasFeeCap)
-
-	senderKey, _ := crypto.GenerateKey()
-	sender := crypto.PubkeyToAddress(senderKey.PublicKey)
-	payerKey, _ := crypto.GenerateKey()
-	feePayer := crypto.PubkeyToAddress(payerKey.PublicKey)
-
-	testAddBalance(pool, sender, new(big.Int).Mul(feeCost, big.NewInt(10)))
-	testAddBalance(pool, feePayer, feeCost)
-
-	// nonce 0 self-paid (closes the gap), nonce 1 fee-delegated (the one under test).
-	fillTx := dynamicFeeTx(0, gasLimit, gasFeeCap, gasTipCap, senderKey)
-	fdTx := feeDelegateTx(chainID, 1, gasLimit, gasFeeCap, gasTipCap, value, senderKey, payerKey)
-	pool.enqueueTx(fillTx.Hash(), fillTx, false, true)
-	pool.enqueueTx(fdTx.Hash(), fdTx, false, true)
-
-	// Fee payer dips below the FD tx's gas cost just before promotion.
-	testAddBalance(pool, feePayer, new(big.Int).Neg(feeCost))
-	pool.promoteExecutables([]common.Address{sender})
-
-	// The FD tx must NOT be dropped: it stays queued (not pending) and tracked.
-	if pool.all.Get(fdTx.Hash()) == nil {
-		t.Fatalf("fee-delegated tx was dropped during a transient fee-payer dip")
-	}
-	if pool.pending[sender] != nil && pool.pending[sender].txs.Get(1) != nil {
-		t.Fatalf("fee-delegated tx promoted while fee payer was insolvent")
-	}
-	if pool.queue[sender] == nil || pool.queue[sender].txs.Get(1) == nil {
-		t.Fatalf("fee-delegated tx should remain queued during the dip")
-	}
-	if g := pool.pendingGas[feePayer]; g != nil && !g.IsZero() {
-		t.Fatalf("pendingGas[feePayer] = %v while FD tx is only queued, want 0", g)
-	}
-
-	// Fee payer is funded again; the next promotion pass must admit the FD tx
-	// automatically, without any resubmission.
-	testAddBalance(pool, feePayer, feeCost)
-	pool.promoteExecutables([]common.Address{sender})
-
-	if pool.pending[sender] == nil || pool.pending[sender].txs.Get(1) == nil {
-		t.Fatalf("fee-delegated tx was not auto-promoted after the fee payer recovered")
-	}
-	if g := pool.pendingGas[feePayer]; g == nil || g.ToBig().Cmp(feeCost) != 0 {
-		t.Fatalf("pendingGas[feePayer] = %v after revival, want %v", g, feeCost)
 	}
 	if err := validateFeeDelegationAccounting(pool); err != nil {
 		t.Fatalf("fee-delegation accounting drift: %v", err)

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3137,3 +3137,98 @@ func BenchmarkMultiAccountBatchInsert(b *testing.B) {
 		pool.addRemotesSync([]*types.Transaction{tx})
 	}
 }
+
+// feeDelegateTx builds a fee delegation dynamic-fee transaction signed by both
+// the sender (over the inner DynamicFeeTx) and the fee payer (over the wrapping
+// FeeDelegateDynamicFeeTx).
+func feeDelegateTx(chainID *big.Int, nonce uint64, gas uint64, gasFeeCap, gasTipCap, value *big.Int, senderKey, feePayerKey *ecdsa.PrivateKey) *types.Transaction {
+	to := common.Address{}
+	inner := types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+		Gas:       gas,
+		To:        &to,
+		Value:     value,
+	}
+	signedSender := types.MustSignNewTx(senderKey, types.LatestSignerForChainID(chainID), &inner)
+	v, r, s := signedSender.RawSignatureValues()
+	inner.V, inner.R, inner.S = v, r, s
+
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	fd := &types.FeeDelegateDynamicFeeTx{FeePayer: &feePayer}
+	fd.SetSenderTx(inner)
+	return types.MustSignNewTx(feePayerKey, types.NewFeeDelegateSigner(chainID), fd)
+}
+
+// TestFeeDelegationCumulativeGas verifies that the pool aggregates the gas
+// obligations of fee delegation transactions per fee payer across the many
+// sender lists it subsidises, and rejects new transactions once that aggregate
+// would overdraw the fee payer's balance, while leaving the per-sender value
+// accounting intact.
+func TestFeeDelegationCumulativeGas(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0) // enable fee delegation tx type
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gas = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	perTxGas := new(big.Int).Mul(big.NewInt(gas), gasFeeCap) // FeeCost per tx
+
+	// Fee payer can cover exactly two transactions' gas, not three.
+	feePayerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	testAddBalance(pool, feePayer, new(big.Int).Add(new(big.Int).Mul(perTxGas, big.NewInt(2)), new(big.Int).Div(perTxGas, big.NewInt(2))))
+
+	// Three distinct senders, each amply funded for their own value transfer.
+	senders := make([]*ecdsa.PrivateKey, 3)
+	txs := make([]*types.Transaction, 3)
+	for i := range senders {
+		senders[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(senders[i].PublicKey), big.NewInt(1_000_000))
+		txs[i] = feeDelegateTx(chainID, 0, gas, gasFeeCap, gasTipCap, value, senders[i], feePayerKey)
+	}
+
+	// First two transactions fit within the fee payer's balance.
+	if err := pool.Add([]*types.Transaction{txs[0]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 0: unexpected error: %v", err)
+	}
+	if err := pool.Add([]*types.Transaction{txs[1]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 1: unexpected error: %v", err)
+	}
+
+	// The pool-wide gas index must now reflect both transactions' fees.
+	pool.mu.RLock()
+	gotGas := new(big.Int)
+	if g := pool.pendingGas[feePayer]; g != nil {
+		gotGas = g.ToBig()
+	}
+	pool.mu.RUnlock()
+	if want := new(big.Int).Mul(perTxGas, big.NewInt(2)); gotGas.Cmp(want) != 0 {
+		t.Fatalf("pendingGas[feePayer] = %v, want %v", gotGas, want)
+	}
+
+	// The third transaction is individually affordable, but pushes the fee
+	// payer's aggregate gas obligation over its balance and must be rejected.
+	if err := pool.Add([]*types.Transaction{txs[2]}, true, true)[0]; !errors.Is(err, txpool.ErrFeePayerInsufficientFunds) {
+		t.Fatalf("tx 2: error = %v, want %v", err, txpool.ErrFeePayerInsufficientFunds)
+	}
+
+	// Removing one accepted transaction frees enough of the fee payer's budget
+	// for the previously rejected one to be admitted, proving the index is also
+	// maintained on removal.
+	pool.removeTx(txs[0].Hash(), false, true)
+	if err := pool.Add([]*types.Transaction{txs[2]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 2 after removal: unexpected error: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3232,3 +3232,449 @@ func TestFeeDelegationCumulativeGas(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 }
+
+// TestPendingGasZeroAccounting verifies that fee-delegated transactions whose gas
+// obligation is zero (e.g. a zero gas-fee-cap tx) do not corrupt the pool-wide
+// per-fee-payer gas index. addPendingGas creates an entry on first use and
+// subPendingGas deletes it once it reaches zero and panics on a missing one, so a
+// naive implementation would: create a zero entry, delete it on the first
+// removal, then panic on the second removal of another zero-gas tx sharing the
+// fee payer. The accounting must skip zero contributions symmetrically instead.
+func TestPendingGasZeroAccounting(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0)
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	payerKey, _ := crypto.GenerateKey()
+	payer := crypto.PubkeyToAddress(payerKey.PublicKey)
+	zero := new(uint256.Int)
+	five := uint256.NewInt(5)
+
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	// Two zero-gas obligations sharing a fee payer: the second removal must not
+	// panic on a missing map entry.
+	pool.addPendingGas(payer, zero)
+	pool.addPendingGas(payer, zero)
+	if _, ok := pool.pendingGas[payer]; ok {
+		t.Fatalf("zero gas obligation must not create a pendingGas entry")
+	}
+	pool.subPendingGas(payer, zero)
+	pool.subPendingGas(payer, zero)
+
+	// Mixed: a real obligation kept alongside a zero one. Removing the real one
+	// first drives the running total to zero and deletes the entry; the later
+	// zero removal must still be a no-op rather than a panic.
+	pool.addPendingGas(payer, five)
+	pool.addPendingGas(payer, zero)
+	if got := pool.pendingGas[payer]; got == nil || got.Cmp(five) != 0 {
+		t.Fatalf("pendingGas[payer] = %v, want %v", got, five)
+	}
+	pool.subPendingGas(payer, five)
+	if _, ok := pool.pendingGas[payer]; ok {
+		t.Fatalf("pendingGas entry must be deleted once it reaches zero")
+	}
+	pool.subPendingGas(payer, zero) // must not panic on the now-absent entry
+}
+
+// TestFeeDelegationCumulativeGasOnPromotion verifies that the cumulative fee
+// payer affordability check is also enforced when queued transactions are
+// promoted to the pending set, not only on submission. Queued (non-executable)
+// transactions are not tracked in the per-fee-payer gas index, so several of
+// them sharing one fee payer can each pass the submission-time check in
+// isolation; the promotion path must re-check the aggregate and reject the ones
+// that would overdraw the fee payer once they become executable together.
+func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0) // enable fee delegation tx type
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gas = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	perTxGas := new(big.Int).Mul(big.NewInt(gas), gasFeeCap) // FeeCost per tx
+
+	// Fee payer can cover exactly two transactions' gas, not three.
+	feePayerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	testAddBalance(pool, feePayer, new(big.Int).Add(new(big.Int).Mul(perTxGas, big.NewInt(2)), new(big.Int).Div(perTxGas, big.NewInt(2))))
+
+	// Three distinct senders, each amply funded for a self-paid nonce-0 tx and a
+	// fee-delegated nonce-1 tx's value.
+	senders := make([]*ecdsa.PrivateKey, 3)
+	gapTxs := make([]*types.Transaction, 3)  // nonce 1, fee-delegated (fee payer pays gas)
+	fillTxs := make([]*types.Transaction, 3) // nonce 0, self-paid (closes the gap)
+	for i := range senders {
+		senders[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(senders[i].PublicKey), new(big.Int).Mul(perTxGas, big.NewInt(10)))
+		gapTxs[i] = feeDelegateTx(chainID, 1, gas, gasFeeCap, gasTipCap, value, senders[i], feePayerKey)
+		fillTxs[i] = dynamicFeeTx(0, gas, gasFeeCap, gasTipCap, senders[i])
+	}
+
+	// All three fee-delegated txs have a nonce gap, so they sit in the queue. The
+	// per-fee-payer gas index only tracks pending txs, so each one passes the
+	// submission-time cumulative check in isolation (the index reads zero).
+	for i, tx := range gapTxs {
+		if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
+			t.Fatalf("gap tx %d: unexpected error: %v", i, err)
+		}
+	}
+	pool.mu.RLock()
+	if g := pool.pendingGas[feePayer]; g != nil && !g.IsZero() {
+		pool.mu.RUnlock()
+		t.Fatalf("pendingGas[feePayer] = %v before promotion, want 0 (queued txs must not be tracked)", g)
+	}
+	pool.mu.RUnlock()
+
+	// Close each gap one sender at a time, so promotion is deterministic: the
+	// third sender's fee-delegated tx is the one that overdraws the fee payer.
+	for i, tx := range fillTxs {
+		if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
+			t.Fatalf("fill tx %d: unexpected error: %v", i, err)
+		}
+	}
+
+	// Exactly two fee-delegated txs must have been promoted to pending; the third
+	// fails the promotion-time cumulative check. Under Peek-then-Admit it is NOT
+	// dropped: it (and its nonce tail) stays in the queue to be retried later, so
+	// all three remain tracked in pool.all.
+	pool.mu.RLock()
+	gotGas := new(big.Int)
+	if g := pool.pendingGas[feePayer]; g != nil {
+		gotGas = g.ToBig()
+	}
+	pendingFD, queuedFD := 0, 0
+	for i, tx := range gapTxs {
+		sender := crypto.PubkeyToAddress(senders[i].PublicKey)
+		if pool.all.Get(tx.Hash()) == nil {
+			pool.mu.RUnlock()
+			t.Fatalf("gap tx %d was dropped from pool.all; Peek-then-Admit must retain rejected txs", i)
+		}
+		switch {
+		case pool.pending[sender] != nil && pool.pending[sender].txs.Get(tx.Nonce()) != nil:
+			pendingFD++
+		case pool.queue[sender] != nil && pool.queue[sender].txs.Get(tx.Nonce()) != nil:
+			queuedFD++
+		default:
+			pool.mu.RUnlock()
+			t.Fatalf("gap tx %d is in neither the pending nor the queue list", i)
+		}
+	}
+	feePayerBalance := pool.currentState.GetBalance(feePayer).ToBig()
+	pool.mu.RUnlock()
+
+	if want := new(big.Int).Mul(perTxGas, big.NewInt(2)); gotGas.Cmp(want) != 0 {
+		t.Fatalf("pendingGas[feePayer] = %v after promotion, want %v", gotGas, want)
+	}
+	if pendingFD != 2 || queuedFD != 1 {
+		t.Fatalf("fee-delegated txs: %d pending, %d queued, want 2 pending and 1 queued", pendingFD, queuedFD)
+	}
+	// The fee payer's aggregate gas obligation must never exceed its balance.
+	if gotGas.Cmp(feePayerBalance) > 0 {
+		t.Fatalf("pendingGas[feePayer] = %v exceeds balance %v", gotGas, feePayerBalance)
+	}
+
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+	if err := validateFeeDelegationAccounting(pool); err != nil {
+		t.Fatalf("fee-delegation accounting drift: %v", err)
+	}
+}
+
+// validateFeeDelegationAccounting recomputes the fee-delegation accounting from
+// the live pending/queue contents and compares it against the maintained values.
+// validatePoolInternals does not cover these, so it cannot catch drift in the
+// per-list feeDelegated counter, totalvalue/totalgas, or the pool-wide pendingGas.
+func validateFeeDelegationAccounting(pool *LegacyPool) error {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	wantPendingGas := make(map[common.Address]*big.Int)
+
+	// feeDelegated counter must match the number of FD txs held by every list.
+	countFD := func(l *list) int {
+		fd := 0
+		for _, tx := range l.txs.items {
+			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+				fd++
+			}
+		}
+		return fd
+	}
+
+	for addr, l := range pool.pending {
+		if fd := countFD(l); l.feeDelegated != fd {
+			return fmt.Errorf("pending[%s].feeDelegated = %d, recomputed %d", addr.Hex(), l.feeDelegated, fd)
+		}
+		sumValue, sumGasNonFD := new(big.Int), new(big.Int)
+		for _, tx := range l.txs.items {
+			sumValue.Add(sumValue, tx.Value())
+			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+				p := *tx.FeePayer()
+				acc := wantPendingGas[p]
+				if acc == nil {
+					acc = new(big.Int)
+					wantPendingGas[p] = acc
+				}
+				acc.Add(acc, tx.FeeCost())
+			} else {
+				sumGasNonFD.Add(sumGasNonFD, tx.FeeCost())
+			}
+		}
+		if l.totalvalue.ToBig().Cmp(sumValue) != 0 {
+			return fmt.Errorf("pending[%s].totalvalue = %v, recomputed %v", addr.Hex(), l.totalvalue, sumValue)
+		}
+		if l.totalgas.ToBig().Cmp(sumGasNonFD) != 0 {
+			return fmt.Errorf("pending[%s].totalgas = %v, recomputed %v", addr.Hex(), l.totalgas, sumGasNonFD)
+		}
+	}
+	for addr, l := range pool.queue {
+		if fd := countFD(l); l.feeDelegated != fd {
+			return fmt.Errorf("queue[%s].feeDelegated = %d, recomputed %d", addr.Hex(), l.feeDelegated, fd)
+		}
+	}
+	// pendingGas[payer] must equal the summed FeeCost of pending FD txs charging
+	// it. A zero sum must have no entry (addPendingGas skips zero contributions).
+	for payer, want := range wantPendingGas {
+		got := pool.pendingGas[payer]
+		if want.Sign() == 0 {
+			if got != nil {
+				return fmt.Errorf("pendingGas[%s] = %v, want no entry (zero obligation)", payer.Hex(), got)
+			}
+			continue
+		}
+		if got == nil || got.ToBig().Cmp(want) != 0 {
+			return fmt.Errorf("pendingGas[%s] = %v, recomputed %v", payer.Hex(), got, want)
+		}
+	}
+	for payer, got := range pool.pendingGas {
+		if wantPendingGas[payer] == nil && !got.IsZero() {
+			return fmt.Errorf("pendingGas[%s] = %v but no pending FD tx charges it", payer.Hex(), got)
+		}
+	}
+	return nil
+}
+
+// TestPeekReadyNonDestructive verifies that list.PeekReady returns the same
+// contiguous run as Ready without removing anything, that it is self-correcting
+// (returns from the heap minimum even when start is higher), and that
+// RemoveReadyPrefix removes only the admitted prefix.
+func TestPeekReadyNonDestructive(t *testing.T) {
+	t.Parallel()
+
+	key, _ := crypto.GenerateKey()
+	l := newList(false)
+	for _, n := range []uint64{0, 1, 2, 4} { // gap at nonce 3
+		l.Add(transaction(n, 0, key), DefaultConfig.PriceBump)
+	}
+
+	// PeekReady returns the contiguous run 0,1,2 (stops at the gap) without removing.
+	ready := l.PeekReady(0)
+	if len(ready) != 3 || ready[0].Nonce() != 0 || ready[1].Nonce() != 1 || ready[2].Nonce() != 2 {
+		t.Fatalf("PeekReady(0) returned wrong run: %v", nonceSlice(ready))
+	}
+	if l.txs.Len() != 4 {
+		t.Fatalf("PeekReady must not remove items: Len = %d, want 4", l.txs.Len())
+	}
+
+	// Self-correcting: even with start beyond the minimum it returns from the heap
+	// minimum (0,1,2), mirroring Ready, so low-nonce txs are never stranded.
+	if got := l.PeekReady(2); len(got) != 3 || got[0].Nonce() != 0 {
+		t.Fatalf("PeekReady(2) = %v, want run starting at heap minimum 0", nonceSlice(got))
+	}
+
+	// Remove only the admitted prefix (0,1); nonces 2 and 4 stay queued.
+	l.RemoveReadyPrefix(ready[:2])
+	if l.txs.Len() != 2 || l.txs.Get(0) != nil || l.txs.Get(1) != nil {
+		t.Fatalf("RemoveReadyPrefix must remove exactly nonces 0,1 (Len=%d)", l.txs.Len())
+	}
+	if l.txs.Get(2) == nil || l.txs.Get(4) == nil {
+		t.Fatalf("RemoveReadyPrefix removed more than the prefix")
+	}
+}
+
+func nonceSlice(txs types.Transactions) []uint64 {
+	out := make([]uint64, len(txs))
+	for i, tx := range txs {
+		out[i] = tx.Nonce()
+	}
+	return out
+}
+
+// TestListFeeDelegatedCounter verifies that the per-list feeDelegated counter is
+// kept in sync across adds, fee-delegated replacements (subtract old + add new),
+// and removals routed through subCosts.
+func TestListFeeDelegatedCounter(t *testing.T) {
+	t.Parallel()
+
+	chainID := params.TestChainConfig.ChainID
+	senderKey, _ := crypto.GenerateKey()
+	payerKey, _ := crypto.GenerateKey()
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+
+	l := newList(false)
+	l.Add(dynamicFeeTx(0, 21000, gasFeeCap, gasTipCap, senderKey), DefaultConfig.PriceBump)
+	l.Add(feeDelegateTx(chainID, 1, 21000, gasFeeCap, gasTipCap, big.NewInt(1), senderKey, payerKey), DefaultConfig.PriceBump)
+	l.Add(feeDelegateTx(chainID, 2, 21000, gasFeeCap, gasTipCap, big.NewInt(1), senderKey, payerKey), DefaultConfig.PriceBump)
+	if l.feeDelegated != 2 {
+		t.Fatalf("feeDelegated = %d after adds, want 2", l.feeDelegated)
+	}
+
+	// Replace the nonce-1 FD tx with a higher-priced FD tx: net counter change 0.
+	higher := feeDelegateTx(chainID, 1, 21000, big.NewInt(2_000_000_000), big.NewInt(2), big.NewInt(1), senderKey, payerKey)
+	if _, err := l.Add(higher, DefaultConfig.PriceBump); err != nil {
+		t.Fatalf("replacement add: %v", err)
+	}
+	if l.feeDelegated != 2 {
+		t.Fatalf("feeDelegated = %d after FD->FD replacement, want 2", l.feeDelegated)
+	}
+
+	// Forward(2) removes nonces 0 (normal) and 1 (FD); the counter drops by one.
+	l.Forward(2)
+	if l.feeDelegated != 1 {
+		t.Fatalf("feeDelegated = %d after Forward(2), want 1", l.feeDelegated)
+	}
+}
+
+// TestFeeDelegationFilterShortCircuitGate verifies that a pending fee-delegated
+// transaction whose fee payer became insolvent is demoted even when the sender's
+// balance still covers the cached cost cap. Without the feeDelegated gate the
+// Filter short-circuit (keyed on the sender balance) would skip the per-tx
+// fee-payer balance check and leave the unpayable tx pending.
+func TestFeeDelegationFilterShortCircuitGate(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0)
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gasLimit = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	feeCost := new(big.Int).Mul(big.NewInt(gasLimit), gasFeeCap)
+
+	senderKey, _ := crypto.GenerateKey()
+	sender := crypto.PubkeyToAddress(senderKey.PublicKey)
+	payerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(payerKey.PublicKey)
+
+	// Sender holds far more than tx.Cost() (value + gas), so the Filter cost/gas
+	// short-circuit would skip the per-tx fee-payer check without the gate. The
+	// fee payer is funded for exactly one transaction's gas.
+	testAddBalance(pool, sender, new(big.Int).Mul(feeCost, big.NewInt(100)))
+	testAddBalance(pool, feePayer, feeCost)
+
+	tx := feeDelegateTx(chainID, 0, gasLimit, gasFeeCap, gasTipCap, value, senderKey, payerKey)
+	if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	pool.mu.RLock()
+	inPending := pool.pending[sender] != nil && pool.pending[sender].txs.Get(0) != nil
+	pool.mu.RUnlock()
+	if !inPending {
+		t.Fatalf("fee-delegated tx was not promoted to pending")
+	}
+
+	// Drain the fee payer below its FeeCost; the sender balance stays high.
+	testAddBalance(pool, feePayer, new(big.Int).Neg(feeCost))
+
+	pool.mu.Lock()
+	pool.demoteUnexecutables()
+	pool.mu.Unlock()
+
+	pool.mu.RLock()
+	stillPending := pool.pending[sender] != nil && pool.pending[sender].txs.Get(0) != nil
+	pg := pool.pendingGas[feePayer]
+	pool.mu.RUnlock()
+	if stillPending {
+		t.Fatalf("insolvent fee-payer tx still pending; Filter short-circuit gate not working")
+	}
+	if pg != nil && !pg.IsZero() {
+		t.Fatalf("pendingGas[feePayer] = %v after demote, want 0", pg)
+	}
+	if err := validateFeeDelegationAccounting(pool); err != nil {
+		t.Fatalf("fee-delegation accounting drift: %v", err)
+	}
+}
+
+// TestFeeDelegationFeePayerDipRevives verifies the promotion-path liveness goal:
+// a queued fee-delegated tx whose fee payer is only temporarily insolvent is not
+// dropped by the promote-time Filter (enforceFeePayer=false). It stays queued
+// while the fee payer is short, and is promoted automatically once the fee payer
+// can afford it again, without the sender having to resubmit.
+func TestFeeDelegationFeePayerDipRevives(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0)
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gasLimit = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	feeCost := new(big.Int).Mul(big.NewInt(gasLimit), gasFeeCap)
+
+	senderKey, _ := crypto.GenerateKey()
+	sender := crypto.PubkeyToAddress(senderKey.PublicKey)
+	payerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(payerKey.PublicKey)
+
+	testAddBalance(pool, sender, new(big.Int).Mul(feeCost, big.NewInt(10)))
+	testAddBalance(pool, feePayer, feeCost)
+
+	// nonce 0 self-paid (closes the gap), nonce 1 fee-delegated (the one under test).
+	fillTx := dynamicFeeTx(0, gasLimit, gasFeeCap, gasTipCap, senderKey)
+	fdTx := feeDelegateTx(chainID, 1, gasLimit, gasFeeCap, gasTipCap, value, senderKey, payerKey)
+	pool.enqueueTx(fillTx.Hash(), fillTx, false, true)
+	pool.enqueueTx(fdTx.Hash(), fdTx, false, true)
+
+	// Fee payer dips below the FD tx's gas cost just before promotion.
+	testAddBalance(pool, feePayer, new(big.Int).Neg(feeCost))
+	pool.promoteExecutables([]common.Address{sender})
+
+	// The FD tx must NOT be dropped: it stays queued (not pending) and tracked.
+	if pool.all.Get(fdTx.Hash()) == nil {
+		t.Fatalf("fee-delegated tx was dropped during a transient fee-payer dip")
+	}
+	if pool.pending[sender] != nil && pool.pending[sender].txs.Get(1) != nil {
+		t.Fatalf("fee-delegated tx promoted while fee payer was insolvent")
+	}
+	if pool.queue[sender] == nil || pool.queue[sender].txs.Get(1) == nil {
+		t.Fatalf("fee-delegated tx should remain queued during the dip")
+	}
+	if g := pool.pendingGas[feePayer]; g != nil && !g.IsZero() {
+		t.Fatalf("pendingGas[feePayer] = %v while FD tx is only queued, want 0", g)
+	}
+
+	// Fee payer is funded again; the next promotion pass must admit the FD tx
+	// automatically, without any resubmission.
+	testAddBalance(pool, feePayer, feeCost)
+	pool.promoteExecutables([]common.Address{sender})
+
+	if pool.pending[sender] == nil || pool.pending[sender].txs.Get(1) == nil {
+		t.Fatalf("fee-delegated tx was not auto-promoted after the fee payer recovered")
+	}
+	if g := pool.pendingGas[feePayer]; g == nil || g.ToBig().Cmp(feeCost) != 0 {
+		t.Fatalf("pendingGas[feePayer] = %v after revival, want %v", g, feeCost)
+	}
+	if err := validateFeeDelegationAccounting(pool); err != nil {
+		t.Fatalf("fee-delegation accounting drift: %v", err)
+	}
+}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -277,16 +277,36 @@ type list struct {
 	costcap   *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
 	gascap    uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
 	totalcost *uint256.Int // Total cost of all transactions in the list
+
+	// totalvalue is the cumulative tx.Value() of every transaction in the list,
+	// i.e. the amount this account owes purely as a *sender* (regardless of who
+	// pays the gas). Used for the cumulative overdraft check.
+	totalvalue *uint256.Int
+
+	// totalgas is the cumulative gas-side cost (tx.FeeCost()) of the transactions
+	// in this list for which this account is also the gas payer, i.e. every
+	// non-fee-delegated transaction. Gas owed via fee delegation is attributed to
+	// the fee payer through pendingGas instead, since that account may not have a
+	// list of its own.
+	totalgas *uint256.Int
+
+	// pendingGas is a pool-wide map (shared by reference across all per-account
+	// lists) tracking the cumulative gas (tx.FeeCost()) each account owes when it
+	// acts as the fee payer of fee-delegated transactions. nil is tolerated
+	// (e.g. in unit tests), in which case fee-delegation gas is simply not tracked.
+	pendingGas map[common.Address]*uint256.Int
 }
 
 // newList creates a new transaction list for maintaining nonce-indexable fast,
 // gapped, sortable transaction lists.
 func newList(strict bool) *list {
 	return &list{
-		strict:    strict,
-		txs:       newSortedMap(),
-		costcap:   new(uint256.Int),
-		totalcost: new(uint256.Int),
+		strict:     strict,
+		txs:        newSortedMap(),
+		costcap:    new(uint256.Int),
+		totalcost:  new(uint256.Int),
+		totalvalue: new(uint256.Int),
+		totalgas:   new(uint256.Int),
 	}
 }
 
@@ -333,6 +353,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		return false, nil
 	}
 	l.totalcost.Add(l.totalcost, cost)
+	l.addCost(tx)
 
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
@@ -471,6 +492,60 @@ func (l *list) subTotalCost(txs []*types.Transaction) {
 		if underflow {
 			panic("totalcost underflow")
 		}
+		l.subCost(tx)
+	}
+}
+
+// addCost attributes a transaction's value and gas obligations to the right
+// accounts: the value is always owed by the sender (this list's owner), while
+// the gas is owed by the sender for normal transactions or by the fee payer for
+// fee-delegated transactions (tracked pool-wide via pendingGas).
+func (l *list) addCost(tx *types.Transaction) {
+	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
+
+	feeCost := uint256.MustFromBig(tx.FeeCost())
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+		if l.pendingGas == nil {
+			return
+		}
+		payer := *tx.FeePayer()
+		acc := l.pendingGas[payer]
+		if acc == nil {
+			acc = new(uint256.Int)
+			l.pendingGas[payer] = acc
+		}
+		acc.Add(acc, feeCost)
+		return
+	}
+	l.totalgas.Add(l.totalgas, feeCost)
+}
+
+// subCost reverses addCost for a removed transaction.
+func (l *list) subCost(tx *types.Transaction) {
+	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
+		panic("totalvalue underflow")
+	}
+
+	feeCost := uint256.MustFromBig(tx.FeeCost())
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+		if l.pendingGas == nil {
+			return
+		}
+		payer := *tx.FeePayer()
+		acc := l.pendingGas[payer]
+		if acc == nil {
+			panic("pendingGas underflow")
+		}
+		if _, underflow := acc.SubOverflow(acc, feeCost); underflow {
+			panic("pendingGas underflow")
+		}
+		if acc.IsZero() {
+			delete(l.pendingGas, payer)
+		}
+		return
+	}
+	if _, underflow := l.totalgas.SubOverflow(l.totalgas, feeCost); underflow {
+		panic("totalgas underflow")
 	}
 }
 

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -512,11 +512,14 @@ func (l *list) subCosts(txs []*types.Transaction) {
 // tracksExpenditure reports whether this list participates in pending
 // expenditure accounting. The pendingGas callbacks must be wired as a pair so
 // addCost/subCost remain symmetric.
+
 func (l *list) tracksExpenditure() bool {
-	if (l.addPendingGas == nil) != (l.subPendingGas == nil) {
+	hasAddPendingGas := l.addPendingGas != nil
+	hasSubPendingGas := l.subPendingGas != nil
+	if hasAddPendingGas != hasSubPendingGas {
 		panic("inconsistent pendingGas callbacks would corrupt gas accounting")
 	}
-	return l.addPendingGas != nil
+	return hasAddPendingGas
 }
 
 // addCost updates pending-only expenditure accounting.

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -267,6 +267,27 @@ func (m *sortedMap) LastElement() *types.Transaction {
 	return cache[len(cache)-1]
 }
 
+// PeekReady returns the same contiguous run of ready transactions as Ready, but
+// without removing them from the map. Like Ready it starts from the heap minimum
+// nonce (not from start) whenever that minimum is <= start, so transactions with
+// a nonce below start are also returned to stay self-correcting.
+func (m *sortedMap) PeekReady(start uint64) types.Transactions {
+	if m.index.Len() == 0 || (*m.index)[0] > start {
+		return nil
+	}
+	var ready types.Transactions
+	// Walk from the heap minimum, not from start, and stop at the first gap
+	// (equivalent to Ready's heap-front condition).
+	for next := (*m.index)[0]; ; next++ {
+		tx := m.items[next]
+		if tx == nil {
+			break
+		}
+		ready = append(ready, tx)
+	}
+	return ready
+}
+
 // list is a "list" of transactions belonging to an account, sorted by account
 // nonce. The same type can be used both for storing contiguous transactions for
 // the executable/pending queue; and for storing gapped transactions for the non-
@@ -289,6 +310,12 @@ type list struct {
 	// the fee payer through pendingGas instead, since that account may not have a
 	// list of its own.
 	totalgas *uint256.Int
+
+	// feeDelegated counts the fee-delegated transactions currently held. While it
+	// is non-zero the Filter short-circuit is suppressed so the per-tx fee-payer
+	// balance check always runs. Maintained for every list (queue lists included),
+	// hence outside the tracksExpenditure guard.
+	feeDelegated int
 
 	// addPendingGas and subPendingGas update pool-wide fee-payer gas accounting
 	// for fee-delegated transactions in pending lists.
@@ -317,14 +344,22 @@ func (l *list) Contains(nonce uint64) bool {
 // Add tries to insert a new transaction into the list, returning any previous
 // transaction it replaced, or an error if the transaction was rejected (e.g.
 // underpriced replacement or invalid fee payer). On success, the list updates
-// its cost/gas thresholds and expenditure accounting (totalvalue, totalgas,
-// and pool-wide pendingGas for fee-delegated transactions).
+// its cost/gas thresholds, the feeDelegated counter, and expenditure accounting
+// (totalvalue, totalgas, and pool-wide pendingGas for fee-delegated transactions).
 func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction, error) {
 	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
 	// unreachable on the normal path. Keep the invariant local to list.Add too.
 	// if it ever were reached, the caller may surface this as ErrReplaceUnderpriced (when colliding on nonce)
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		return nil, txpool.ErrInvalidFeePayer
+	}
+	// Compute the cost and reject on overflow before mutating any accounting.
+	// Otherwise a replacement that bails out here would already have subtracted
+	// the old transaction's cost (and decremented feeDelegated), leaving the old
+	// transaction in the map but no longer accounted for.
+	cost, overflow := uint256.FromBig(tx.Cost())
+	if overflow {
+		return nil, txpool.ErrReplaceUnderpriced
 	}
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
@@ -351,15 +386,12 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction,
 		// Old is being replaced, subtract old cost
 		l.subCosts([]*types.Transaction{old})
 	}
-	cost, overflow := uint256.FromBig(tx.Cost())
-	if overflow {
-		return nil, txpool.ErrReplaceUnderpriced
-	}
 	if err := l.addCost(tx); err != nil {
 		return nil, err
 	}
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
+	l.incFeeDelegated(tx)
 	if l.costcap.Cmp(cost) < 0 {
 		l.costcap = cost
 	}
@@ -383,13 +415,22 @@ func (l *list) Forward(threshold uint64) types.Transactions {
 // post-removal maintenance. Strict-mode invalidated transactions are also
 // returned.
 //
-// This method uses the cached costcap and gascap to quickly decide if there's even
-// a point in calculating all the costs or if the balance covers all. If the threshold
-// is lower than the costgas cap, the caps will be reset to a new high after removing
-// the newly invalidated transactions.
-func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uint256.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
-	// If all transactions are below the threshold, short circuit
-	if l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
+// The cached costcap/gascap allow a quick short-circuit when the balance covers
+// every transaction, but it is suppressed while the list holds any fee-delegated
+// transaction (feeDelegated > 0): costcap is keyed on the sender balance and
+// cannot represent the separate fee-payer balance dimension. When the short-circuit
+// is skipped the caps are reset to the provided thresholds.
+//
+// enforceFeePayer controls whether fee-delegated transactions are dropped when
+// their fee payer can no longer afford the gas. It is set on demotion (pending
+// txs must stay payable) and cleared on promotion: a queued fee-delegated tx
+// whose fee payer is only temporarily insolvent is then retained and retried
+// rather than dropped, since queued txs are not in pending/pendingGas/blocks and
+// carry no affordability guarantee yet.
+func (l *list) Filter(feeDelegation bool, enforceFeePayer bool, stateDB *state.StateDB, costLimit *uint256.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
+	// Short circuit only when every tx is below the thresholds AND the list holds
+	// no fee-delegated tx (the cap check ignores the fee-payer balance dimension).
+	if l.feeDelegated == 0 && l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
 		return nil, nil
 	}
 	l.costcap = new(uint256.Int).Set(costLimit) // Lower the caps to the thresholds
@@ -398,7 +439,12 @@ func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uin
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
 		if feeDelegation && tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
-			return tx.Gas() > gasLimit || tx.FeeCost().Cmp(stateDB.GetBalance(*tx.FeePayer()).ToBig()) > 0 || tx.Value().Cmp(costLimit.ToBig()) > 0
+			// The sender always owes the value and the gas must fit the block;
+			// the fee payer's balance is only enforced when requested (demotion).
+			if tx.Gas() > gasLimit || tx.Value().Cmp(costLimit.ToBig()) > 0 {
+				return true
+			}
+			return enforceFeePayer && tx.FeeCost().Cmp(stateDB.GetBalance(*tx.FeePayer()).ToBig()) > 0
 		}
 		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit.ToBig()) > 0
 	})
@@ -450,6 +496,23 @@ func (l *list) Remove(tx *types.Transaction) (bool, types.Transactions) {
 	return true, nil
 }
 
+// PeekReady returns the ready transactions without removing them, mirroring
+// Ready's contiguous-run semantics. Used by promotion to validate fee-delegated
+// transactions before deciding which prefix to admit.
+func (l *list) PeekReady(start uint64) types.Transactions {
+	return l.txs.PeekReady(start)
+}
+
+// RemoveReadyPrefix removes the given (already peeked) transactions from the list
+// and reverses their cost accounting. Only the admitted prefix is passed in, so
+// any transactions left behind by promotion stay queued.
+func (l *list) RemoveReadyPrefix(txs types.Transactions) {
+	for _, tx := range txs {
+		l.txs.Remove(tx.Nonce())
+	}
+	l.subCosts(txs) // reverse totalvalue/totalgas/pendingGas and feeDelegated
+}
+
 // Ready retrieves a sequentially increasing list of transactions starting at the
 // provided nonce that is ready for processing. The returned transactions will be
 // removed from the list.
@@ -486,9 +549,27 @@ func (l *list) LastElement() *types.Transaction {
 	return l.txs.LastElement()
 }
 
-// subCosts applies subCost to each of the given transactions.
+func (l *list) incFeeDelegated(tx *types.Transaction) {
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		l.feeDelegated++
+	}
+}
+func (l *list) decFeeDelegated(tx *types.Transaction) {
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		l.feeDelegated--
+		if l.feeDelegated < 0 {
+			panic("feeDelegated counter underflow")
+		}
+	}
+}
+
+// subCosts reverses the accounting for each removed transaction: it decrements
+// the feeDelegated counter and applies subCost (totalvalue/totalgas, or pendingGas
+// for fee-delegated txs). It is the single chokepoint shared by every removal path
+// (Forward/Filter/Cap/Remove/Ready/RemoveReadyPrefix), so the counter stays in sync.
 func (l *list) subCosts(txs []*types.Transaction) {
 	for _, tx := range txs {
+		l.decFeeDelegated(tx)
 		l.subCost(tx)
 	}
 }

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -299,22 +299,11 @@ type list struct {
 	costcap *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
 	gascap  uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
 
-	// totalvalue is the cumulative tx.Value() of every transaction in the list,
-	// i.e. the amount this account owes purely as a *sender* (regardless of who
-	// pays the gas). Used for the cumulative overdraft check.
-	totalvalue *uint256.Int
+	// totalcost tracks the sender-side pending cost:
+	// tx.Cost() for non-fee-delegated txs, tx.Value() for fee-delegated txs.
+	totalcost *uint256.Int
 
-	// totalgas is the cumulative gas-side cost (tx.FeeCost()) of the transactions
-	// in this list for which this account is also the gas payer, i.e. every
-	// non-fee-delegated transaction. Gas owed via fee delegation is attributed to
-	// the fee payer through pendingGas instead, since that account may not have a
-	// list of its own.
-	totalgas *uint256.Int
-
-	// feeDelegated counts the fee-delegated transactions currently held. While it
-	// is non-zero the Filter short-circuit is suppressed so the per-tx fee-payer
-	// balance check always runs. Maintained for every list (queue lists included),
-	// hence outside the tracksExpenditure guard.
+	// feeDelegated counts the fee-delegated transactions currently held.
 	feeDelegated int
 
 	// addPendingGas and subPendingGas update pool-wide fee-payer gas accounting
@@ -327,11 +316,10 @@ type list struct {
 // gapped, sortable transaction lists.
 func newList(strict bool) *list {
 	return &list{
-		strict:     strict,
-		txs:        newSortedMap(),
-		costcap:    new(uint256.Int),
-		totalvalue: new(uint256.Int),
-		totalgas:   new(uint256.Int),
+		strict:    strict,
+		txs:       newSortedMap(),
+		costcap:   new(uint256.Int),
+		totalcost: new(uint256.Int),
 	}
 }
 
@@ -342,10 +330,7 @@ func (l *list) Contains(nonce uint64) bool {
 }
 
 // Add tries to insert a new transaction into the list, returning any previous
-// transaction it replaced, or an error if the transaction was rejected (e.g.
-// underpriced replacement or invalid fee payer). On success, the list updates
-// its cost/gas thresholds, the feeDelegated counter, and expenditure accounting
-// (totalvalue, totalgas, and pool-wide pendingGas for fee-delegated transactions).
+// transaction it replaced, or an error if the transaction was rejected
 func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction, error) {
 	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
 	// unreachable on the normal path. Keep the invariant local to list.Add too.
@@ -510,7 +495,7 @@ func (l *list) RemoveReadyPrefix(txs types.Transactions) {
 	for _, tx := range txs {
 		l.txs.Remove(tx.Nonce())
 	}
-	l.subCosts(txs) // reverse totalvalue/totalgas/pendingGas and feeDelegated
+	l.subCosts(txs) // reverse totalcost/pendingGas and feeDelegated
 }
 
 // Ready retrieves a sequentially increasing list of transactions starting at the
@@ -563,10 +548,6 @@ func (l *list) decFeeDelegated(tx *types.Transaction) {
 	}
 }
 
-// subCosts reverses the accounting for each removed transaction: it decrements
-// the feeDelegated counter and applies subCost (totalvalue/totalgas, or pendingGas
-// for fee-delegated txs). It is the single chokepoint shared by every removal path
-// (Forward/Filter/Cap/Remove/Ready/RemoveReadyPrefix), so the counter stays in sync.
 func (l *list) subCosts(txs []*types.Transaction) {
 	for _, tx := range txs {
 		l.decFeeDelegated(tx)
@@ -577,7 +558,7 @@ func (l *list) subCosts(txs []*types.Transaction) {
 // tracksExpenditure reports whether this list is wired for the pool-wide fee-payer
 // gas accounting (pending lists are; queue/test lists are not). The two callbacks
 // are always set as a pair — if only one were nil, addCost/subCost would diverge
-// and the accounting (totalvalue/pendingGas) would become wrong, so a half-wired
+// and the accounting (totalcost/pendingGas) would become wrong, so a half-wired
 // state is treated as a fatal wiring bug and panics. Used as the top-level guard
 // in addCost/subCost so both stay symmetric.
 func (l *list) tracksExpenditure() bool {
@@ -587,10 +568,7 @@ func (l *list) tracksExpenditure() bool {
 	return l.addPendingGas != nil
 }
 
-// addCost updates the expenditure counters used by pending-only overdraft
-// accounting. Lists without pending-gas callbacks are unwired queue/test lists;
-// their counters are intentionally unused by ExistingExpenditure, so value and
-// gas are skipped together.
+// addCost updates pending-only expenditure accounting.
 func (l *list) addCost(tx *types.Transaction) error {
 	if !l.tracksExpenditure() {
 		return nil
@@ -598,13 +576,12 @@ func (l *list) addCost(tx *types.Transaction) error {
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		return txpool.ErrInvalidFeePayer
 	}
-	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
-	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		l.addPendingGas(*tx.FeePayer(), feeCost)
+		l.totalcost.Add(l.totalcost, uint256.MustFromBig(tx.Value()))
+		l.addPendingGas(*tx.FeePayer(), uint256.MustFromBig(tx.FeeCost()))
 		return nil
 	}
-	l.totalgas.Add(l.totalgas, feeCost)
+	l.totalcost.Add(l.totalcost, uint256.MustFromBig(tx.Cost()))
 	return nil
 }
 
@@ -616,16 +593,15 @@ func (l *list) subCost(tx *types.Transaction) {
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		panic("fee-delegated tx missing fee payer in subCost")
 	}
-	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
-		panic("totalvalue underflow")
-	}
-	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		l.subPendingGas(*tx.FeePayer(), feeCost)
+		if _, underflow := l.totalcost.SubOverflow(l.totalcost, uint256.MustFromBig(tx.Value())); underflow {
+			panic("totalcost underflow")
+		}
+		l.subPendingGas(*tx.FeePayer(), uint256.MustFromBig(tx.FeeCost()))
 		return
 	}
-	if _, underflow := l.totalgas.SubOverflow(l.totalgas, feeCost); underflow {
-		panic("totalgas underflow")
+	if _, underflow := l.totalcost.SubOverflow(l.totalcost, uint256.MustFromBig(tx.Cost())); underflow {
+		panic("totalcost underflow")
 	}
 }
 

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
 )
 
@@ -315,22 +314,23 @@ func (l *list) Contains(nonce uint64) bool {
 	return l.txs.Get(nonce) != nil
 }
 
-// Add tries to insert a new transaction into the list, returning whether the
-// transaction was accepted, and if yes, any previous transaction it replaced.
-// If the new transaction is accepted into the list, the lists' cost and gas
-// thresholds are also potentially updated.
-func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transaction, error) {
+// Add tries to insert a new transaction into the list, returning any previous
+// transaction it replaced, or an error if the transaction was rejected (e.g.
+// underpriced replacement or invalid fee payer). On success, the list updates
+// its cost/gas thresholds and expenditure accounting (totalvalue, totalgas,
+// and pool-wide pendingGas for fee-delegated transactions).
+func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction, error) {
 	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
 	// unreachable on the normal path. Keep the invariant local to list.Add too.
 	// if it ever were reached, the caller may surface this as ErrReplaceUnderpriced (when colliding on nonce)
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
-		return false, nil, txpool.ErrInvalidFeePayer
+		return nil, txpool.ErrInvalidFeePayer
 	}
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
 		if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
-			return false, nil, nil
+			return nil, txpool.ErrReplaceUnderpriced
 		}
 		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
 		a := big.NewInt(100 + int64(priceBump))
@@ -346,18 +346,18 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements.
 		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
-			return false, nil, nil
+			return nil, txpool.ErrReplaceUnderpriced
 		}
 		// Old is being replaced, subtract old cost
 		l.subCosts([]*types.Transaction{old})
 	}
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
-		return false, nil, nil
+		return nil, txpool.ErrReplaceUnderpriced
 	}
-
-	l.addCost(tx)
-
+	if err := l.addCost(tx); err != nil {
+		return nil, err
+	}
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
 	if l.costcap.Cmp(cost) < 0 {
@@ -366,7 +366,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 	if gas := tx.Gas(); l.gascap < gas {
 		l.gascap = gas
 	}
-	return true, old, nil
+	return old, nil
 }
 
 // Forward removes all transactions from the list with a nonce lower than the
@@ -510,22 +510,21 @@ func (l *list) tracksExpenditure() bool {
 // accounting. Lists without pending-gas callbacks are unwired queue/test lists;
 // their counters are intentionally unused by ExistingExpenditure, so value and
 // gas are skipped together.
-func (l *list) addCost(tx *types.Transaction) {
+func (l *list) addCost(tx *types.Transaction) error {
 	if !l.tracksExpenditure() {
-		return
+		return nil
+	}
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
+		return txpool.ErrInvalidFeePayer
 	}
 	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
-
 	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		if tx.FeePayer() == nil {
-			log.Error("fee-delegated tx missing fee payer in addCost", "tx", tx.Hash())
-			return
-		}
 		l.addPendingGas(*tx.FeePayer(), feeCost)
-		return
+		return nil
 	}
 	l.totalgas.Add(l.totalgas, feeCost)
+	return nil
 }
 
 // subCost reverses addCost for a removed transaction.
@@ -533,16 +532,14 @@ func (l *list) subCost(tx *types.Transaction) {
 	if !l.tracksExpenditure() {
 		return
 	}
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
+		panic("fee-delegated tx missing fee payer in subCost")
+	}
 	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
 		panic("totalvalue underflow")
 	}
-
 	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		if tx.FeePayer() == nil {
-			log.Error("fee-delegated tx missing fee payer in subCost", "tx", tx.Hash())
-			return
-		}
 		l.subPendingGas(*tx.FeePayer(), feeCost)
 		return
 	}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -274,9 +274,8 @@ type list struct {
 	strict bool       // Whether nonces are strictly continuous or not
 	txs    *sortedMap // Heap indexed sorted hash map of the transactions
 
-	costcap   *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
-	gascap    uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
-	totalcost *uint256.Int // Total cost of all transactions in the list
+	costcap *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
+	gascap  uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
 
 	// totalvalue is the cumulative tx.Value() of every transaction in the list,
 	// i.e. the amount this account owes purely as a *sender* (regardless of who
@@ -304,7 +303,6 @@ func newList(strict bool) *list {
 		strict:     strict,
 		txs:        newSortedMap(),
 		costcap:    new(uint256.Int),
-		totalcost:  new(uint256.Int),
 		totalvalue: new(uint256.Int),
 		totalgas:   new(uint256.Int),
 	}
@@ -345,14 +343,14 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 			return false, nil
 		}
 		// Old is being replaced, subtract old cost
-		l.subTotalCost([]*types.Transaction{old})
+		l.subCosts([]*types.Transaction{old})
 	}
 	// Add new tx cost to totalcost
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
 		return false, nil
 	}
-	l.totalcost.Add(l.totalcost, cost)
+
 	l.addCost(tx)
 
 	// Otherwise overwrite the old transaction with the current one
@@ -371,7 +369,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 // maintenance.
 func (l *list) Forward(threshold uint64) types.Transactions {
 	txs := l.txs.Forward(threshold)
-	l.subTotalCost(txs)
+	l.subCosts(txs)
 	return txs
 }
 
@@ -415,8 +413,8 @@ func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uin
 		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
 	}
 	// Reset total cost
-	l.subTotalCost(removed)
-	l.subTotalCost(invalids)
+	l.subCosts(removed)
+	l.subCosts(invalids)
 	l.txs.reheap()
 	return removed, invalids
 }
@@ -425,7 +423,7 @@ func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uin
 // exceeding that limit.
 func (l *list) Cap(threshold int) types.Transactions {
 	txs := l.txs.Cap(threshold)
-	l.subTotalCost(txs)
+	l.subCosts(txs)
 	return txs
 }
 
@@ -438,11 +436,11 @@ func (l *list) Remove(tx *types.Transaction) (bool, types.Transactions) {
 	if removed := l.txs.Remove(nonce); !removed {
 		return false, nil
 	}
-	l.subTotalCost([]*types.Transaction{tx})
+	l.subCosts([]*types.Transaction{tx})
 	// In strict mode, filter out non-executable transactions
 	if l.strict {
 		txs := l.txs.Filter(func(tx *types.Transaction) bool { return tx.Nonce() > nonce })
-		l.subTotalCost(txs)
+		l.subCosts(txs)
 		return true, txs
 	}
 	return true, nil
@@ -457,7 +455,7 @@ func (l *list) Remove(tx *types.Transaction) (bool, types.Transactions) {
 // happen but better to be self correcting than failing!
 func (l *list) Ready(start uint64) types.Transactions {
 	txs := l.txs.Ready(start)
-	l.subTotalCost(txs)
+	l.subCosts(txs)
 	return txs
 }
 
@@ -484,14 +482,9 @@ func (l *list) LastElement() *types.Transaction {
 	return l.txs.LastElement()
 }
 
-// subTotalCost subtracts the cost of the given transactions from the
-// total cost of all transactions.
-func (l *list) subTotalCost(txs []*types.Transaction) {
+// subCosts applies subCost to each of the given transactions.
+func (l *list) subCosts(txs []*types.Transaction) {
 	for _, tx := range txs {
-		_, underflow := l.totalcost.SubOverflow(l.totalcost, uint256.MustFromBig(tx.Cost()))
-		if underflow {
-			panic("totalcost underflow")
-		}
 		l.subCost(tx)
 	}
 }

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -267,27 +267,6 @@ func (m *sortedMap) LastElement() *types.Transaction {
 	return cache[len(cache)-1]
 }
 
-// PeekReady returns the same contiguous run of ready transactions as Ready, but
-// without removing them from the map. Like Ready it starts from the heap minimum
-// nonce (not from start) whenever that minimum is <= start, so transactions with
-// a nonce below start are also returned to stay self-correcting.
-func (m *sortedMap) PeekReady(start uint64) types.Transactions {
-	if m.index.Len() == 0 || (*m.index)[0] > start {
-		return nil
-	}
-	var ready types.Transactions
-	// Walk from the heap minimum, not from start, and stop at the first gap
-	// (equivalent to Ready's heap-front condition).
-	for next := (*m.index)[0]; ; next++ {
-		tx := m.items[next]
-		if tx == nil {
-			break
-		}
-		ready = append(ready, tx)
-	}
-	return ready
-}
-
 // list is a "list" of transactions belonging to an account, sorted by account
 // nonce. The same type can be used both for storing contiguous transactions for
 // the executable/pending queue; and for storing gapped transactions for the non-
@@ -406,13 +385,9 @@ func (l *list) Forward(threshold uint64) types.Transactions {
 // cannot represent the separate fee-payer balance dimension. When the short-circuit
 // is skipped the caps are reset to the provided thresholds.
 //
-// enforceFeePayer controls whether fee-delegated transactions are dropped when
-// their fee payer can no longer afford the gas. It is set on demotion (pending
-// txs must stay payable) and cleared on promotion: a queued fee-delegated tx
-// whose fee payer is only temporarily insolvent is then retained and retried
-// rather than dropped, since queued txs are not in pending/pendingGas/blocks and
-// carry no affordability guarantee yet.
-func (l *list) Filter(feeDelegation bool, enforceFeePayer bool, stateDB *state.StateDB, costLimit *uint256.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
+// For fee-delegated transactions the sender's value and the gas limit are checked
+// as usual, and the fee payer's balance must cover the gas cost.
+func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uint256.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
 	// Short circuit only when every tx is below the thresholds AND the list holds
 	// no fee-delegated tx (the cap check ignores the fee-payer balance dimension).
 	if l.feeDelegated == 0 && l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
@@ -424,12 +399,11 @@ func (l *list) Filter(feeDelegation bool, enforceFeePayer bool, stateDB *state.S
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
 		if feeDelegation && tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
-			// The sender always owes the value and the gas must fit the block;
-			// the fee payer's balance is only enforced when requested (demotion).
-			if tx.Gas() > gasLimit || tx.Value().Cmp(costLimit.ToBig()) > 0 {
-				return true
-			}
-			return enforceFeePayer && tx.FeeCost().Cmp(stateDB.GetBalance(*tx.FeePayer()).ToBig()) > 0
+			// Sender owes the value, the gas must fit the block, and the fee payer
+			// must cover the gas cost.
+			return tx.Gas() > gasLimit ||
+				tx.Value().Cmp(costLimit.ToBig()) > 0 ||
+				tx.FeeCost().Cmp(stateDB.GetBalance(*tx.FeePayer()).ToBig()) > 0
 		}
 		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit.ToBig()) > 0
 	})
@@ -479,23 +453,6 @@ func (l *list) Remove(tx *types.Transaction) (bool, types.Transactions) {
 		return true, txs
 	}
 	return true, nil
-}
-
-// PeekReady returns the ready transactions without removing them, mirroring
-// Ready's contiguous-run semantics. Used by promotion to validate fee-delegated
-// transactions before deciding which prefix to admit.
-func (l *list) PeekReady(start uint64) types.Transactions {
-	return l.txs.PeekReady(start)
-}
-
-// RemoveReadyPrefix removes the given (already peeked) transactions from the list
-// and reverses their cost accounting. Only the admitted prefix is passed in, so
-// any transactions left behind by promotion stay queued.
-func (l *list) RemoveReadyPrefix(txs types.Transactions) {
-	for _, tx := range txs {
-		l.txs.Remove(tx.Nonce())
-	}
-	l.subCosts(txs) // reverse totalcost/pendingGas and feeDelegated
 }
 
 // Ready retrieves a sequentially increasing list of transactions starting at the

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -345,7 +345,6 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		// Old is being replaced, subtract old cost
 		l.subCosts([]*types.Transaction{old})
 	}
-	// Add new tx cost to totalcost
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
 		return false, nil
@@ -412,7 +411,6 @@ func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uin
 		}
 		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
 	}
-	// Reset total cost
 	l.subCosts(removed)
 	l.subCosts(invalids)
 	l.txs.reheap()

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
 )
 
@@ -289,11 +290,10 @@ type list struct {
 	// list of its own.
 	totalgas *uint256.Int
 
-	// pendingGas is a pool-wide map (shared by reference across all per-account
-	// lists) tracking the cumulative gas (tx.FeeCost()) each account owes when it
-	// acts as the fee payer of fee-delegated transactions. nil is tolerated
-	// (e.g. in unit tests), in which case fee-delegation gas is simply not tracked.
-	pendingGas map[common.Address]*uint256.Int
+	// addPendingGas and subPendingGas update pool-wide fee-payer gas accounting
+	// for fee-delegated transactions in pending lists.
+	addPendingGas func(common.Address, *uint256.Int)
+	subPendingGas func(common.Address, *uint256.Int)
 }
 
 // newList creates a new transaction list for maintaining nonce-indexable fast,
@@ -489,25 +489,36 @@ func (l *list) subCosts(txs []*types.Transaction) {
 	}
 }
 
-// addCost attributes a transaction's value and gas obligations to the right
-// accounts: the value is always owed by the sender (this list's owner), while
-// the gas is owed by the sender for normal transactions or by the fee payer for
-// fee-delegated transactions (tracked pool-wide via pendingGas).
+// tracksExpenditure reports whether this list is wired for the pool-wide fee-payer
+// gas accounting (pending lists are; queue/test lists are not). The two callbacks
+// are always set as a pair — if only one were nil, addCost/subCost would diverge
+// and the accounting (totalvalue/pendingGas) would become wrong, so a half-wired
+// state is treated as a fatal wiring bug and panics. Used as the top-level guard
+// in addCost/subCost so both stay symmetric.
+func (l *list) tracksExpenditure() bool {
+	if (l.addPendingGas == nil) != (l.subPendingGas == nil) {
+		panic("legacypool: inconsistent pendingGas callbacks would corrupt gas accounting ")
+	}
+	return l.addPendingGas != nil
+}
+
+// addCost updates the expenditure counters used by pending-only overdraft
+// accounting. Lists without pending-gas callbacks are unwired queue/test lists;
+// their counters are intentionally unused by ExistingExpenditure, so value and
+// gas are skipped together.
 func (l *list) addCost(tx *types.Transaction) {
+	if !l.tracksExpenditure() {
+		return
+	}
 	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
 
 	feeCost := uint256.MustFromBig(tx.FeeCost())
-	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
-		if l.pendingGas == nil {
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		if tx.FeePayer() == nil {
+			log.Error("fee-delegated tx missing fee payer in addCost", "tx", tx.Hash())
 			return
 		}
-		payer := *tx.FeePayer()
-		acc := l.pendingGas[payer]
-		if acc == nil {
-			acc = new(uint256.Int)
-			l.pendingGas[payer] = acc
-		}
-		acc.Add(acc, feeCost)
+		l.addPendingGas(*tx.FeePayer(), feeCost)
 		return
 	}
 	l.totalgas.Add(l.totalgas, feeCost)
@@ -515,26 +526,20 @@ func (l *list) addCost(tx *types.Transaction) {
 
 // subCost reverses addCost for a removed transaction.
 func (l *list) subCost(tx *types.Transaction) {
+	if !l.tracksExpenditure() {
+		return
+	}
 	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
 		panic("totalvalue underflow")
 	}
 
 	feeCost := uint256.MustFromBig(tx.FeeCost())
-	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
-		if l.pendingGas == nil {
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		if tx.FeePayer() == nil {
+			log.Error("fee-delegated tx missing fee payer in subCost", "tx", tx.Hash())
 			return
 		}
-		payer := *tx.FeePayer()
-		acc := l.pendingGas[payer]
-		if acc == nil {
-			panic("pendingGas underflow")
-		}
-		if _, underflow := acc.SubOverflow(acc, feeCost); underflow {
-			panic("pendingGas underflow")
-		}
-		if acc.IsZero() {
-			delete(l.pendingGas, payer)
-		}
+		l.subPendingGas(*tx.FeePayer(), feeCost)
 		return
 	}
 	if _, underflow := l.totalgas.SubOverflow(l.totalgas, feeCost); underflow {

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
@@ -316,15 +317,20 @@ func (l *list) Contains(nonce uint64) bool {
 
 // Add tries to insert a new transaction into the list, returning whether the
 // transaction was accepted, and if yes, any previous transaction it replaced.
-//
 // If the new transaction is accepted into the list, the lists' cost and gas
 // thresholds are also potentially updated.
-func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transaction) {
+func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transaction, error) {
+	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
+	// unreachable on the normal path. Keep the invariant local to list.Add too.
+	// if it ever were reached, the caller may surface this as ErrReplaceUnderpriced (when colliding on nonce)
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
+		return false, nil, txpool.ErrInvalidFeePayer
+	}
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
 		if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
-			return false, nil
+			return false, nil, nil
 		}
 		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
 		a := big.NewInt(100 + int64(priceBump))
@@ -340,14 +346,14 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements.
 		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
-			return false, nil
+			return false, nil, nil
 		}
 		// Old is being replaced, subtract old cost
 		l.subCosts([]*types.Transaction{old})
 	}
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
-		return false, nil
+		return false, nil, nil
 	}
 
 	l.addCost(tx)
@@ -360,7 +366,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 	if gas := tx.Gas(); l.gascap < gas {
 		l.gascap = gas
 	}
-	return true, old
+	return true, old, nil
 }
 
 // Forward removes all transactions from the list with a nonce lower than the

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -501,7 +501,7 @@ func (l *list) subCosts(txs []*types.Transaction) {
 // in addCost/subCost so both stay symmetric.
 func (l *list) tracksExpenditure() bool {
 	if (l.addPendingGas == nil) != (l.subPendingGas == nil) {
-		panic("legacypool: inconsistent pendingGas callbacks would corrupt gas accounting ")
+		panic("inconsistent pendingGas callbacks would corrupt gas accounting")
 	}
 	return l.addPendingGas != nil
 }

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -311,16 +311,13 @@ func (l *list) Contains(nonce uint64) bool {
 // Add tries to insert a new transaction into the list, returning any previous
 // transaction it replaced, or an error if the transaction was rejected
 func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction, error) {
-	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
-	// unreachable on the normal path. Keep the invariant local to list.Add too.
-	// if it ever were reached, the caller may surface this as ErrReplaceUnderpriced (when colliding on nonce)
+	// ValidateTransaction rejects fee-delegated txs without a fee payer before they
+	// reach the list, but keep the invariant local because addCost/subCost require it.
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		return nil, txpool.ErrInvalidFeePayer
 	}
-	// Compute the cost and reject on overflow before mutating any accounting.
-	// Otherwise a replacement that bails out here would already have subtracted
-	// the old transaction's cost (and decremented feeDelegated), leaving the old
-	// transaction in the map but no longer accounted for.
+	// Reject overflow before mutating accounting, otherwise a failed replacement
+	// could leave the old tx in the map but missing from the list counters.
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
 		return nil, txpool.ErrReplaceUnderpriced
@@ -512,12 +509,9 @@ func (l *list) subCosts(txs []*types.Transaction) {
 	}
 }
 
-// tracksExpenditure reports whether this list is wired for the pool-wide fee-payer
-// gas accounting (pending lists are; queue/test lists are not). The two callbacks
-// are always set as a pair — if only one were nil, addCost/subCost would diverge
-// and the accounting (totalcost/pendingGas) would become wrong, so a half-wired
-// state is treated as a fatal wiring bug and panics. Used as the top-level guard
-// in addCost/subCost so both stay symmetric.
+// tracksExpenditure reports whether this list participates in pending
+// expenditure accounting. The pendingGas callbacks must be wired as a pair so
+// addCost/subCost remain symmetric.
 func (l *list) tracksExpenditure() bool {
 	if (l.addPendingGas == nil) != (l.subPendingGas == nil) {
 		panic("inconsistent pendingGas callbacks would corrupt gas accounting")

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -84,7 +84,7 @@ func BenchmarkListAdd(b *testing.B) {
 		list := newList(true)
 		for _, v := range rand.Perm(len(txs)) {
 			list.Add(txs[v], DefaultConfig.PriceBump)
-			list.Filter(false, nil, priceLimit, DefaultConfig.PriceBump)
+			list.Filter(false, true, nil, priceLimit, DefaultConfig.PriceBump)
 		}
 	}
 }

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -84,7 +84,7 @@ func BenchmarkListAdd(b *testing.B) {
 		list := newList(true)
 		for _, v := range rand.Perm(len(txs)) {
 			list.Add(txs[v], DefaultConfig.PriceBump)
-			list.Filter(false, true, nil, priceLimit, DefaultConfig.PriceBump)
+			list.Filter(false, nil, priceLimit, DefaultConfig.PriceBump)
 		}
 	}
 }

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -308,14 +308,14 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		// whichever account currently carries it (value -> sender, gas -> its own
 		// gas payer, which may differ from the new transaction's gas payer).
 		var (
-			hasPrev      bool
-			prevGasPayer = from
-			prevValue    = new(big.Int)
-			prevGasCost  = new(big.Int)
+			isReplacement bool
+			prevGasPayer  = from
+			prevValue     = new(big.Int)
+			prevGasCost   = new(big.Int)
 		)
 		if opts.ExistingTx != nil {
 			if prev := opts.ExistingTx(from, tx.Nonce()); prev != nil {
-				hasPrev = true
+				isReplacement = true
 				prevValue = prev.Value()
 				prevGasCost = prev.FeeCost()
 				if prev.Type() == types.FeeDelegateDynamicFeeTxType && prev.FeePayer() != nil {
@@ -325,23 +325,16 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		} else if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
 			// Pools without fee-delegation support (e.g. the blob pool): the replaced
 			// transaction is fully sender-paid, so its whole cost belongs to the sender.
-			hasPrev = true
+			isReplacement = true
 			prevGasCost = prev // prev == old.Cost(); oldGasPayer == from
 		}
 
 		// need computes an account's total pooled obligation (value owed as a
 		// sender plus gas owed as a gas payer), augmented by the incoming
 		// transaction's deltas and discounted by any transaction being replaced.
-		need := func(addr common.Address, curValue, curGasCost *big.Int) *big.Int {
+		need := func(addr common.Address, curValue, curGasCost *big.Int) (*big.Int, error) {
 			n := new(big.Int).Set(opts.ExistingExpenditure(addr))
-			// Incoming tx contribution.
-			if addr == from {
-				n.Add(n, curValue)
-			}
-			if addr == gasPayer {
-				n.Add(n, curGasCost)
-			}
-			if hasPrev {
+			if isReplacement {
 				if addr == from {
 					n.Sub(n, prevValue)
 				}
@@ -349,13 +342,19 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 					n.Sub(n, prevGasCost)
 				}
 				if n.Sign() < 0 {
-					n.SetInt64(0) // guard against accounting drift
+					return nil, fmt.Errorf("%w: addr %v, underflow %v",
+						core.ErrTxPoolAccountingUnderflow, addr, new(big.Int).Neg(n))
 				}
 			}
-			return n
+			// Incoming tx contribution.
+			if addr == from {
+				n.Add(n, curValue)
+			}
+			if addr == gasPayer {
+				n.Add(n, curGasCost)
+			}
+			return n, nil
 		}
-
-
 		if from == gasPayer {
 			// Self-paid: value and gas are drawn from the same balance and must be
 			// checked combined, otherwise an account could overdraft by splitting
@@ -387,6 +386,5 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 			}
 		}
 	}
-
 	return nil
 }

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -208,13 +208,25 @@ type ValidationOptionsWithState struct {
 	// be rejected once the number of remaining slots reaches zero.
 	UsedAndLeftSlots func(addr common.Address) (int, int)
 
-	// ExistingExpenditure is a mandatory callback to retrieve the cumulative
-	// cost of the already pooled transactions to check for overdrafts.
+	// ExistingExpenditure is a mandatory callback to retrieve an account's total
+	// cumulative obligation across every role it plays in the pending set: value
+	// it owes as a sender, gas it owes as its own gas payer, and gas it owes as a
+	// fee payer for others' fee-delegated transactions. This single "total
+	// obligation" view keeps the overdraft check correct for both ordinary and
+	// fee-delegated transactions.
 	ExistingExpenditure func(addr common.Address) *big.Int
 
 	// ExistingCost is a mandatory callback to retrieve an already pooled
 	// transaction's cost with the given nonce to check for overdrafts.
 	ExistingCost func(addr common.Address, nonce uint64) *big.Int
+
+	// ExistingTx is an optional callback to retrieve the already pooled
+	// transaction (if any) with the given sender and nonce, i.e. the transaction
+	// that an incoming one would replace. It lets the cumulative overdraft check
+	// split the replaced transaction's value and gas across the right accounts,
+	// which is required for fee-delegated transactions. When nil, the check falls
+	// back to ExistingCost and assumes the replaced transaction was sender-paid.
+	ExistingTx func(addr common.Address, nonce uint64) *types.Transaction
 }
 
 // ValidateTransactionWithState is a helper method to check whether a transaction
@@ -267,34 +279,98 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		}
 	}
 
-	// go-wbft skips cumulative balance validation for fee delegation tx compatibility.
-	// Fee delegation transactions split costs between sender (value only) and feePayer (gas fees),
-	// but ExistingExpenditure callback sums total tx.Cost() which is incompatible with this model.
-	// Enabling this validation would incorrectly reject transactions when fee delegation txs exist
-	// in the pending pool, as it would compare sender's balance against the full cost (value + gas).
-	// Transaction replacement is still supported via legacypool's price bump mechanism.
-	/*
-		// Ensure the transactor has enough funds to cover for replacements or nonce
-		// expansions without overdrafts
-		spent := opts.ExistingExpenditure(from)
-		if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
-			bump := new(big.Int).Sub(cost, prev)
-			need := new(big.Int).Add(spent, bump)
-			if balance.Cmp(need) < 0 {
-				return fmt.Errorf("%w: balance %v, queued cost %v, tx bumped %v, overshot %v", core.ErrInsufficientFunds, balance, spent, bump, new(big.Int).Sub(need, balance))
+	// Cumulative overdraft protection (DoS hardening).
+	//
+	// A transaction can clear the per-tx balance checks above yet still be
+	// uncoverable once combined with the account's other pooled obligations. Left
+	// unchecked, an attacker can flood the pool with individually-valid but
+	// collectively-unfundable transactions (sequential value overdrafts from one
+	// sender, or many senders piling gas onto a single fee payer) that mostly
+	// revert on execution and pollute the mempool.
+	//
+	// Fee delegation (tx type 0x16) splits an obligation across two accounts: the
+	// sender owes the value, the fee payer owes the gas (FeeCost). The
+	// ExistingExpenditure callback therefore reports each account's *total*
+	// obligation across every role it plays (value as sender, gas as its own gas
+	// payer, and gas as a fee payer for others), so the checks below remain correct
+	// for both normal and fee-delegated transactions.
+	if opts.ExistingExpenditure != nil {
+		// Determine who is responsible for the gas fee of the incoming transaction.
+		gasPayer := from
+		if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+			gasPayer = *tx.FeePayer()
+		}
+		txValue := tx.Value()
+		txGasCost := tx.FeeCost() // tx.Cost() - tx.Value()
+
+		// If a transaction with the same sender and nonce is already pooled, the
+		// incoming one replaces it, so its contribution must be discounted from
+		// whichever account currently carries it (value -> sender, gas -> its own
+		// gas payer, which may differ from the new transaction's gas payer).
+		var (
+			hasPrev      bool
+			prevGasPayer = from
+			prevValue    = new(big.Int)
+			prevGasCost  = new(big.Int)
+		)
+		if opts.ExistingTx != nil {
+			if prev := opts.ExistingTx(from, tx.Nonce()); prev != nil {
+				hasPrev = true
+				prevValue = prev.Value()
+				prevGasCost = prev.FeeCost()
+				if prev.Type() == types.FeeDelegateDynamicFeeTxType && prev.FeePayer() != nil {
+					prevGasPayer = *prev.FeePayer()
+				}
+			}
+		} else if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
+			// Pools without fee-delegation support (e.g. the blob pool): the replaced
+			// transaction is fully sender-paid, so its whole cost belongs to the sender.
+			hasPrev = true
+			prevGasCost = prev // prev == old.Cost(); oldGasPayer == from
+		}
+
+		// need computes an account's total pooled obligation (value owed as a
+		// sender plus gas owed as a gas payer), augmented by the incoming
+		// transaction's deltas and discounted by any transaction being replaced.
+		need := func(addr common.Address, addValue, addGas *big.Int) *big.Int {
+			n := new(big.Int).Set(opts.ExistingExpenditure(addr))
+			n.Add(n, addValue)
+			n.Add(n, addGas)
+			if hasPrev {
+				if addr == from {
+					n.Sub(n, prevValue)
+				}
+				if addr == prevGasPayer {
+					n.Sub(n, prevGasCost)
+				}
+				if n.Sign() < 0 {
+					n.SetInt64(0) // guard against accounting drift
+				}
+			}
+			return n
+		}
+
+		zero := new(big.Int)
+		if from == gasPayer {
+			// Self-paid: value and gas are drawn from the same balance and must be
+			// checked combined, otherwise an account could overdraft by splitting
+			// its obligations across two independent checks.
+			n := need(from, txValue, txGasCost)
+			if balance.Cmp(n) < 0 {
+				return fmt.Errorf("%w: balance %v, needed %v, overshot %v", core.ErrInsufficientFunds, balance, n, new(big.Int).Sub(n, balance))
 			}
 		} else {
-			need := new(big.Int).Add(spent, cost)
-			if balance.Cmp(need) < 0 {
-				return fmt.Errorf("%w: balance %v, queued cost %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, balance, spent, cost, new(big.Int).Sub(need, balance))
+			// Fee delegation: the sender covers its value obligations, the fee
+			// payer covers its gas obligations, each against its own balance.
+			if nv := need(from, txValue, zero); balance.Cmp(nv) < 0 {
+				return fmt.Errorf("%w: sender balance %v, needed %v, overshot %v", ErrSenderInsufficientFunds, balance, nv, new(big.Int).Sub(nv, balance))
 			}
-			// Transaction takes a new nonce value out of the pool. Ensure it doesn't
-			// overflow the number of permitted transactions from a single account
-			// (i.e. max cancellable via out-of-bound transaction).
-			if used, left := opts.UsedAndLeftSlots(from); left <= 0 {
-				return fmt.Errorf("%w: pooled %d txs", ErrAccountLimitExceeded, used)
+			feePayerBalance := opts.State.GetBalance(gasPayer).ToBig()
+			if ng := need(gasPayer, zero, txGasCost); feePayerBalance.Cmp(ng) < 0 {
+				return fmt.Errorf("%w: fee payer balance %v, needed %v, overshot %v", ErrFeePayerInsufficientFunds, feePayerBalance, ng, new(big.Int).Sub(ng, feePayerBalance))
 			}
 		}
-	*/
+	}
+
 	return nil
 }

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -208,12 +208,10 @@ type ValidationOptionsWithState struct {
 	// be rejected once the number of remaining slots reaches zero.
 	UsedAndLeftSlots func(addr common.Address) (int, int)
 
-	// ExistingExpenditure is a mandatory callback to retrieve an account's total
-	// cumulative obligation across every role it plays in the pending set: value
-	// it owes as a sender, gas it owes as its own gas payer, and gas it owes as a
-	// fee payer for others' fee-delegated transactions. This single "total
-	// obligation" view keeps the overdraft check correct for both ordinary and
-	// fee-delegated transactions.
+	// ExistingExpenditure retrieves an account's cumulative pending obligation
+	// across all roles: sender value, self-paid gas, and fee-payer gas for delegated
+	// transactions. This lets the overdraft check handle ordinary and fee-delegated
+	// transactions with one account-level balance view.
 	ExistingExpenditure func(addr common.Address) *big.Int
 
 	// ExistingCost is a mandatory callback to retrieve an already pooled
@@ -279,21 +277,17 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		}
 	}
 
-	// Cumulative overdraft protection (DoS hardening).
+	// Cumulative overdraft protection.
 	//
-	// A transaction can clear the per-tx balance checks above yet still be
-	// uncoverable once combined with the account's other pooled obligations. Left
-	// unchecked, an attacker can flood the pool with individually-valid but
-	// collectively-unfundable transactions (sequential value overdrafts from one
-	// sender, or many senders piling gas onto a single fee payer) that mostly
-	// revert on execution and pollute the mempool.
+	// A transaction can pass the per-tx balance checks above but still become
+	// unaffordable when combined with the account's other pending obligations. This
+	// allows individually valid but collectively unfundable transactions to occupy
+	// txpool resources.
 	//
-	// Fee delegation (tx type 0x16) splits an obligation across two accounts: the
-	// sender owes the value, the fee payer owes the gas (FeeCost). The
-	// ExistingExpenditure callback therefore reports each account's *total*
-	// obligation across every role it plays (value as sender, gas as its own gas
-	// payer, and gas as a fee payer for others), so the checks below remain correct
-	// for both normal and fee-delegated transactions.
+	// Fee delegation splits the obligation across two accounts: the sender owes
+	// value and the fee payer owes gas. ExistingExpenditure reports each account's
+	// cumulative pending obligation across all roles, so the checks below work for
+	// both ordinary and fee-delegated transactions.
 	if opts.ExistingExpenditure != nil {
 		// Determine who is responsible for the gas fee of the incoming transaction.
 		gasPayer := from

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -332,10 +332,15 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		// need computes an account's total pooled obligation (value owed as a
 		// sender plus gas owed as a gas payer), augmented by the incoming
 		// transaction's deltas and discounted by any transaction being replaced.
-		need := func(addr common.Address, addValue, addGas *big.Int) *big.Int {
+		need := func(addr common.Address, curValue, curGasCost *big.Int) *big.Int {
 			n := new(big.Int).Set(opts.ExistingExpenditure(addr))
-			n.Add(n, addValue)
-			n.Add(n, addGas)
+			// Incoming tx contribution.
+			if addr == from {
+				n.Add(n, curValue)
+			}
+			if addr == gasPayer {
+				n.Add(n, curGasCost)
+			}
 			if hasPrev {
 				if addr == from {
 					n.Sub(n, prevValue)
@@ -350,24 +355,35 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 			return n
 		}
 
-		zero := new(big.Int)
+
 		if from == gasPayer {
 			// Self-paid: value and gas are drawn from the same balance and must be
 			// checked combined, otherwise an account could overdraft by splitting
 			// its obligations across two independent checks.
-			n := need(from, txValue, txGasCost)
-			if balance.Cmp(n) < 0 {
-				return fmt.Errorf("%w: balance %v, needed %v, overshot %v", core.ErrInsufficientFunds, balance, n, new(big.Int).Sub(n, balance))
+			combinedNeed, err := need(from, txValue, txGasCost)
+			if err != nil {
+				return err
+			}
+			if balance.Cmp(combinedNeed) < 0 {
+				return fmt.Errorf("%w: balance %v, needed %v, overshot %v", core.ErrInsufficientFunds, balance, combinedNeed, new(big.Int).Sub(combinedNeed, balance))
 			}
 		} else {
 			// Fee delegation: the sender covers its value obligations, the fee
 			// payer covers its gas obligations, each against its own balance.
-			if nv := need(from, txValue, zero); balance.Cmp(nv) < 0 {
-				return fmt.Errorf("%w: sender balance %v, needed %v, overshot %v", ErrSenderInsufficientFunds, balance, nv, new(big.Int).Sub(nv, balance))
+			senderNeed, err := need(from, txValue, txGasCost)
+			if err != nil {
+				return err
+			}
+			if balance.Cmp(senderNeed) < 0 {
+				return fmt.Errorf("%w: sender balance %v, needed %v, overshot %v", ErrSenderInsufficientFunds, balance, senderNeed, new(big.Int).Sub(senderNeed, balance))
 			}
 			feePayerBalance := opts.State.GetBalance(gasPayer).ToBig()
-			if ng := need(gasPayer, zero, txGasCost); feePayerBalance.Cmp(ng) < 0 {
-				return fmt.Errorf("%w: fee payer balance %v, needed %v, overshot %v", ErrFeePayerInsufficientFunds, feePayerBalance, ng, new(big.Int).Sub(ng, feePayerBalance))
+			feePayerNeed, err := need(gasPayer, txValue, txGasCost)
+			if err != nil {
+				return err
+			}
+			if feePayerBalance.Cmp(feePayerNeed) < 0 {
+				return fmt.Errorf("%w: fee payer balance %v, needed %v, overshot %v", ErrFeePayerInsufficientFunds, feePayerBalance, feePayerNeed, new(big.Int).Sub(feePayerNeed, feePayerBalance))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fee delegation tx (type 0x16) splits cost between sender (value) and feePayer (gas fee). The upstream cumulative overdraft check(introduced in ethereum/go-ethereum#27429) assumed a single payer via `totalcost`, causing false positives for valid fee delegation txs. As a workaround the check was globally disabled, leaving the pool exposed to two DoS vectors:

1. A single sender submitting sequential txs whose aggregate value exceeds balance — each passes per-tx validation individually but reverts on execution, polluting the mempool.
2. Multiple senders designating the same feePayer, collectively exceeding the feePayer's balance with no pool-level rejection.

## Changes

- **list.go**: add `totalvalue`, `totalgas`, `pendingGas` (pool-wide shared map); implement `addCost`/`subCost`. `pendingGas` aggregates gas obligations across all sender lists sharing the same feePayer, enabling cross-sender tracking.
- **legacypool.go**: inject `pendingGas` by reference into each pending list (pending-only). `ExistingExpenditure` returns total obligation across three roles: sender (`totalvalue`), own gas payer (`totalgas`), fee payer for others (`pendingGas`). `ExistingTx` added for correct replacement accounting.
- **validation.go**: replace disabled block with unified cumulative check via `need()`. Normal txs: combined balance check. Fee delegation txs: sender/feePayer checked independently.
- **blobpool_test.go**: restore upstream `core.ErrInsufficientFunds` expectations.
- **legacypool_test.go**: add `TestFeeDelegationCumulativeGas`.

## Test

- [x] `go test ./core/txpool/legacypool/ -run TestFeeDelegationCumulativeGas -v`
- [x] `go test ./core/txpool/legacypool/ ./core/txpool/blobpool/`
- [x] `go test -race ./core/txpool/legacypool/`
