### PR TITLE
fix: prevent forgery and duplicate votes in WBFT justification

### DIFF
--- a/consensus/wbft/core/handler.go
+++ b/consensus/wbft/core/handler.go
@@ -305,6 +305,12 @@ func (c *Core) verifySignatures(m wbfmessage.WBFTMessage) error {
 				return err
 			}
 		}
+		signedPreparePayloads := msgType.JustificationPrepares
+		for _, p := range signedPreparePayloads {
+			if err := verify(p); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/consensus/wbft/core/justification.go
+++ b/consensus/wbft/core/justification.go
@@ -42,21 +42,25 @@ func isJustified(
 	roundChangeMessages []*wbfmessage.SignedRoundChangePayload,
 	prepareMessages []*wbfmessage.Prepare,
 	quorumSize int) error {
+	// Deduplicate by source address to prevent quorum inflation via repeated messages.
+	dedupedRoundChanges := deduplicateRoundChanges(roundChangeMessages)
+	dedupedPrepares := deduplicatePrepares(prepareMessages)
+
 	// Check the size of the set of ROUND-CHANGE messages
-	if len(roundChangeMessages) < quorumSize {
+	if len(dedupedRoundChanges) < quorumSize {
 		return errors.New("number of roundchange messages is less than required quorum of messages")
 	}
 
 	// Check the size of the set of PREPARE messages
-	if len(prepareMessages) != 0 && len(prepareMessages) < quorumSize {
+	if len(dedupedPrepares) != 0 && len(dedupedPrepares) < quorumSize {
 		return errors.New("number of prepared messages is less than required quorum of messages")
 	}
 
 	// If there are PREPARE messages, they all need to have the same round and match `proposal`
 	var preparedRound *big.Int
-	if len(prepareMessages) > 0 {
-		preparedRound = prepareMessages[0].Round
-		for _, spp := range prepareMessages {
+	if len(dedupedPrepares) > 0 {
+		preparedRound = dedupedPrepares[0].Round
+		for _, spp := range dedupedPrepares {
 			if preparedRound.Cmp(spp.Round) != 0 || proposal.Hash() != spp.Digest {
 				return errors.New("prepared messages do not have same round or do not match proposal")
 			}
@@ -64,9 +68,9 @@ func isJustified(
 	}
 
 	if preparedRound == nil {
-		return hasQuorumOfRoundChangeMessagesForNil(roundChangeMessages, quorumSize)
+		return hasQuorumOfRoundChangeMessagesForNil(dedupedRoundChanges, quorumSize)
 	} else {
-		return hasQuorumOfRoundChangeMessagesForPreparedRoundAndBlock(roundChangeMessages, preparedRound, proposal, quorumSize)
+		return hasQuorumOfRoundChangeMessagesForPreparedRoundAndBlock(dedupedRoundChanges, preparedRound, proposal, quorumSize)
 	}
 }
 
@@ -111,11 +115,14 @@ func hasQuorumOfRoundChangeMessagesForPreparedRoundAndBlock(roundChangeMessages 
 // preparedRound and preparedBlockDigest of a ROUND-CHANGE wbfmessage.
 func hasMatchingRoundChangeAndPrepares(
 	roundChange *wbfmessage.RoundChange, prepareMessages []*wbfmessage.Prepare, quorumSize int) error {
-	if len(prepareMessages) < quorumSize {
+	// Deduplicate by source address to prevent quorum inflation from duplicate messages.
+	dedupedPrepares := deduplicatePrepares(prepareMessages)
+
+	if len(dedupedPrepares) < quorumSize {
 		return errors.New("number of prepare messages is less than quorum of messages")
 	}
 
-	for _, spp := range prepareMessages {
+	for _, spp := range dedupedPrepares {
 		if spp.Digest != roundChange.PreparedDigest {
 			return errors.New("prepared message digest does not match roundchange prepared digest")
 		}
@@ -124,4 +131,40 @@ func hasMatchingRoundChangeAndPrepares(
 		}
 	}
 	return nil
+}
+
+// deduplicateRoundChanges returns a new slice with duplicate ROUND-CHANGE
+// messages removed, keeping only the first message per source address.
+// This prevents counting multiple messages from the same validator during quorum size evaluation.
+func deduplicateRoundChanges(msgs []*wbfmessage.SignedRoundChangePayload) []*wbfmessage.SignedRoundChangePayload {
+	seen := make(map[common.Address]struct{}, len(msgs))
+	result := make([]*wbfmessage.SignedRoundChangePayload, 0, len(msgs))
+	for _, m := range msgs {
+		addr := m.Source()
+		if _, dup := seen[addr]; dup {
+			log.Warn("WBFT: duplicate ROUND-CHANGE from same source, skipping", "source", addr)
+			continue
+		}
+		seen[addr] = struct{}{}
+		result = append(result, m)
+	}
+	return result
+}
+
+// deduplicatePrepares returns a new slice with duplicate PREPARE messages
+// removed, keeping only the first message per source address.
+// This prevents counting multiple messages from the same validator during quorum size evaluation.
+func deduplicatePrepares(msgs []*wbfmessage.Prepare) []*wbfmessage.Prepare {
+	seen := make(map[common.Address]struct{}, len(msgs))
+	result := make([]*wbfmessage.Prepare, 0, len(msgs))
+	for _, m := range msgs {
+		addr := m.Source()
+		if _, dup := seen[addr]; dup {
+			log.Warn("WBFT: duplicate PREPARE from same source, skipping", "source", addr)
+			continue
+		}
+		seen[addr] = struct{}{}
+		result = append(result, m)
+	}
+	return result
 }


### PR DESCRIPTION
## Overview
This PR resolves two critical consensus verification vulnerabilities in the WBFT engine by enforcing signature validation for Prepare justifications and preventing duplicate votes in piggybacked consensus messages.

## Problem
1. Prepare messages within `JustificationPrepares` inside a nonzero-round Preprepare message were not signature-verified, allowing a Byzantine proposer to forge arbitrary prepared certificates.
2. Quorum counts for both Round-Change and Prepare justifications were evaluated based purely on slice lengths without checking for duplicate entries from the same validator, enabling a Byzantine proposer to submit duplicate votes to bypass consensus limits and inject fake prepared blocks to poison the local prepared block state.

## Solution
1. Added a cryptographic signature verification loop for `JustificationPrepares` payloads inside `verifySignatures`.
2. Implemented helper functions to deduplicate `RoundChange` and `Prepare` messages by their source address, ensuring each validator's vote is counted at most once during quorum evaluation and prepared state verification (`hasMatchingRoundChangeAndPrepares`).

## Changes
- Add signature verification for `JustificationPrepares` in `consensus/wbft/core/handler.go`
- Implement address-based deduplication for Round-Change and Prepare messages in `consensus/wbft/core/justification.go`
- Filter duplicate entries from quorum and matching message checks in `isJustified`
- Enforce deduplication for Prepare messages inside `hasMatchingRoundChangeAndPrepares` in `consensus/wbft/core/justification.go`