### PR TITLE
fix(txpool): restore cumulative affordability enforcement with fee-delegation accounting

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -129,3 +129,10 @@ var (
 	ErrAuthorizationDestinationHasCode = errors.New("EIP-7702 authorization destination is a contract")
 	ErrAuthorizationNonceMismatch      = errors.New("EIP-7702 authorization nonce does not match current account nonce")
 )
+
+// Internal invariant errors. These indicate bugs in the node's bookkeeping
+// rather than invalid user input, and should be treated as such by callers
+// (e.g. surfaced loudly rather than counted as ordinary validation failures).
+var (
+	ErrTxPoolAccountingUnderflow = errors.New("txpool accounting underflow")
+)

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -1052,7 +1052,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 42200 wei spent: reject nonce 2 with 21100 wei spend (1 wei overflow)
 					from: "alice",
 					tx:   makeUnsignedTx(2, 1, 1, 1),
-					err:  nil, // core.ErrInsufficientFunds; WEMIX does not return error; please refer validation.go:251
+					err:  core.ErrInsufficientFunds,
 				},
 			},
 		},
@@ -1181,7 +1181,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 325344 wei spent: reject nonce 0 with 599684 wei spend (173072 extra) (would overflow balance at nonce 1)
 					from: "alice",
 					tx:   makeUnsignedTx(0, 2, 5, 2),
-					err:  nil, //core.ErrInsufficientFunds,; WEMIX does not return error
+					err:  core.ErrInsufficientFunds,
 				},
 				{ // New account, 2 pooled tx with 325344 wei spent: reject nonce 0 with no-gastip-bump
 					from: "alice",
@@ -1201,7 +1201,7 @@ func TestAdd(t *testing.T) {
 				{ // New account, 2 pooled tx with 325344 wei spent: accept nonce 0 with 84100 wei spend (42000 extra)
 					from: "alice",
 					tx:   makeUnsignedTx(0, 2, 4, 2),
-					err:  txpool.ErrReplaceUnderpriced,
+					err:  nil,
 				},
 			},
 		},

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -687,10 +687,13 @@ func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int
 	}
 }
 
-// validateTx checks whether a transaction is valid according to the consensus
-// rules and adheres to some heuristic limits of the local node (price and size).
-func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
-	opts := &txpool.ValidationOptionsWithState{
+// stateValidationOptions builds the stateful validation options used by
+// ValidateTransactionWithState. Both submission and queued promotion use this
+// builder so nonce, balance, and cumulative overdraft checks stay identical.
+// The expenditure callbacks read pending state at call time, so promotion
+// reflects txs admitted earlier in the same batch. The pool lock must be held.
+func (pool *LegacyPool) stateValidationOptions() *txpool.ValidationOptionsWithState {
+	return &txpool.ValidationOptionsWithState{
 		State: pool.currentState,
 
 		FirstNonceGap:    nil, // Pool allows arbitrary arrival order, don't invalidate nonce gaps
@@ -726,7 +729,12 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 			return nil
 		},
 	}
-	if err := txpool.ValidateTransactionWithState(tx, pool.signer, opts); err != nil {
+}
+
+// validateTx checks whether a transaction is valid according to the consensus
+// rules and adheres to some heuristic limits of the local node (price and size).
+func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
+	if err := txpool.ValidateTransactionWithState(tx, pool.signer, pool.stateValidationOptions()); err != nil {
 		return err
 	}
 	return pool.validateAuth(tx)
@@ -916,7 +924,6 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 			pendingDiscardMeter.Mark(1)
 			return false, err
 		}
-
 		// New transaction is better, replace old one
 		if old != nil {
 			pool.all.Remove(old.Hash())
@@ -991,7 +998,6 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, local
 		queuedDiscardMeter.Mark(1)
 		return false, err
 	}
-
 	// Discard any previous transaction and mark this
 	if old != nil {
 		pool.all.Remove(old.Hash())
@@ -1609,7 +1615,7 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 			pool.all.Remove(hash)
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
-		// Drop all transactions that are too costly (low balance or out of gas)
+		// Drop queued txs that fail per-tx affordability or block gas checks.
 		drops, _ := list.Filter(pool.chainconfig.IsApplepie(pool.currentHead.Load().Number), pool.currentState, pool.currentState.GetBalance(addr), gasLimit)
 		for _, tx := range drops {
 			hash := tx.Hash()
@@ -1618,16 +1624,52 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		log.Trace("Removed unpayable queued transactions", "count", len(drops))
 		queuedNofundsMeter.Mark(int64(len(drops)))
 
-		// Gather all executable transactions and promote them
+		// Gather all executable transactions and promote them. Fee-delegated txs
+		// are re-checked against the shared fee payer's cumulative budget; on the
+		// first failure that tx and its nonce tail are unpromotable, so they are
+		// dropped from the pool (Drop & Forget). Plain txs keep the per-tx behaviour.
 		readies := list.Ready(pool.pendingNonces.get(addr))
-		for _, tx := range readies {
-			hash := tx.Hash()
-			if pool.promoteTx(addr, hash, tx) {
+		before := len(promoted) // promoted is the outer-loop accumulator
+		var (
+			rejectedAtPromote types.Transactions
+			fdOpts            *txpool.ValidationOptionsWithState
+		)
+		for i, tx := range readies {
+			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+				if fdOpts == nil {
+					fdOpts = pool.stateValidationOptions()
+				}
+				if err := txpool.ValidateTransactionWithState(tx, pool.signer, fdOpts); err != nil {
+					rejectedAtPromote = append(rejectedAtPromote, readies[i:]...)
+					break
+				}
+			}
+			if pool.promoteTx(addr, tx.Hash(), tx) {
 				promoted = append(promoted, tx)
+			} else {
+				// promoteTx already removed tx from the global indexes. Ready removed the
+				// whole prefix from the queue, so only the unprocessed nonce tail needs cleanup.
+				rejectedAtPromote = append(rejectedAtPromote, readies[i+1:]...)
+				break
 			}
 		}
-		log.Trace("Promoted queued transactions", "count", len(promoted))
+		log.Trace("Promoted queued transactions", "count", len(promoted)-before)
 		queuedGauge.Dec(int64(len(readies)))
+
+		// Drop the rejected tail. list.Ready already removed them from the queue
+		// list and reversed their cost accounting (subCosts), and queuedGauge was
+		// decremented above via len(readies); only the global lookup, priced index,
+		// and local gauge remain to clean up.
+		for _, tx := range rejectedAtPromote {
+			pool.all.Remove(tx.Hash())
+		}
+		if n := len(rejectedAtPromote); n > 0 {
+			pool.priced.Removed(n)
+			queuedNofundsMeter.Mark(int64(n))
+			if pool.locals.contains(addr) {
+				localGauge.Dec(int64(n))
+			}
+		}
 
 		// Drop all transactions over the allowed limit
 		var caps types.Transactions

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -247,12 +247,13 @@ type LegacyPool struct {
 	locals  *accountSet // Set of local transaction to exempt from eviction rules
 	journal *journal    // Journal of local transaction to back up to disk
 
-	reserver txpool.Reserver              // Address reserver to ensure exclusivity across subpools
-	pending  map[common.Address]*list     // All currently processable transactions
-	queue    map[common.Address]*list     // Queued but non-processable transactions
-	beats    map[common.Address]time.Time // Last heartbeat from each known account
-	all      *lookup                      // All transactions to allow lookups
-	priced   *pricedList                  // All transactions sorted by price
+	reserver   txpool.Reserver                 // Address reserver to ensure exclusivity across subpools
+	pending    map[common.Address]*list        // All currently processable transactions
+	queue      map[common.Address]*list        // Queued but non-processable transactions
+	pendingGas map[common.Address]*uint256.Int // Cumulative pending gas fee indexed by fee payer for fee-delegated txs
+	beats      map[common.Address]time.Time    // Last heartbeat from each known account
+	all        *lookup                         // All transactions to allow lookups
+	priced     *pricedList                     // All transactions sorted by price
 
 	reqResetCh      chan *txpoolResetRequest
 	reqPromoteCh    chan *accountSet
@@ -283,6 +284,7 @@ func New(config Config, chain BlockChain) *LegacyPool {
 		signer:          types.LatestSigner(chain.Config()),
 		pending:         make(map[common.Address]*list),
 		queue:           make(map[common.Address]*list),
+		pendingGas:      make(map[common.Address]*uint256.Int),
 		beats:           make(map[common.Address]time.Time),
 		all:             newLookup(),
 		reqResetCh:      make(chan *txpoolResetRequest),
@@ -656,6 +658,28 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 	return nil
 }
 
+func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int) {
+	acc := pool.pendingGas[payer]
+	if acc == nil {
+		acc = new(uint256.Int)
+		pool.pendingGas[payer] = acc
+	}
+	acc.Add(acc, feeCost)
+}
+
+func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int) {
+	acc := pool.pendingGas[payer]
+	if acc == nil {
+		panic("pendingGas no entry for payer")
+	}
+	if _, underflow := acc.SubOverflow(acc, feeCost); underflow {
+		panic("pendingGas underflow")
+	}
+	if acc.IsZero() {
+		delete(pool.pendingGas, payer)
+	}
+}
+
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
@@ -665,16 +689,32 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 		FirstNonceGap:    nil, // Pool allows arbitrary arrival order, don't invalidate nonce gaps
 		UsedAndLeftSlots: nil, // Pool has own mechanism to limit the number of transactions
 		ExistingExpenditure: func(addr common.Address) *big.Int {
+			// Total wei the account is on the hook for in the pending set (matching
+			// upstream's pending-only accounting): value it owes as a sender, gas it
+			// owes as its own gas payer, and gas it owes as a fee payer for others.
+			// Queued (non-executable) txs are not counted; they are re-checked on
+			// promotion.
+			obligation := new(big.Int)
 			if list := pool.pending[addr]; list != nil {
-				return list.totalcost.ToBig()
+				obligation.Add(obligation, list.totalvalue.ToBig())
+				obligation.Add(obligation, list.totalgas.ToBig())
 			}
-			return new(big.Int)
+			if g := pool.pendingGas[addr]; g != nil {
+				obligation.Add(obligation, g.ToBig())
+			}
+			return obligation
 		},
 		ExistingCost: func(addr common.Address, nonce uint64) *big.Int {
 			if list := pool.pending[addr]; list != nil {
 				if tx := list.txs.Get(nonce); tx != nil {
 					return tx.Cost()
 				}
+			}
+			return nil
+		},
+		ExistingTx: func(addr common.Address, nonce uint64) *types.Transaction {
+			if list := pool.pending[addr]; list != nil {
+				return list.txs.Get(nonce)
 			}
 			return nil
 		},
@@ -988,7 +1028,10 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		pool.pending[addr] = newList(true)
+		list := newList(true)
+		list.addPendingGas = pool.addPendingGas
+		list.subPendingGas = pool.subPendingGas
+		pool.pending[addr] = list
 	}
 	list := pool.pending[addr]
 

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1656,7 +1656,7 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		log.Trace("Promoted queued transactions", "count", len(promoted)-before)
 		queuedGauge.Dec(int64(len(readies)))
 
-		// Drop the rejected tail. list.Ready already removed them from the queue
+		// Drop the rejected txs. list.Ready already removed them from the queue
 		// list and reversed their cost accounting (subCosts), and queuedGauge was
 		// decremented above via len(readies); only the global lookup, priced index,
 		// and local gauge remain to clean up.

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -660,7 +660,6 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 
 func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int) {
 	if feeCost.IsZero() {
-		// Zero-cost removals are no-ops.
 		return
 	}
 	acc := pool.pendingGas[payer]
@@ -697,17 +696,17 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 		FirstNonceGap:    nil, // Pool allows arbitrary arrival order, don't invalidate nonce gaps
 		UsedAndLeftSlots: nil, // Pool has own mechanism to limit the number of transactions
 		ExistingExpenditure: func(addr common.Address) *big.Int {
-			// Total wei the account is on the hook for in the pending set (matching
-			// upstream's pending-only accounting): value it owes as a sender, gas it
-			// owes as its own gas payer, and gas it owes as a fee payer for others.
-			// Queued (non-executable) txs are not counted; they are re-checked on
-			// promotion.
+			// Total wei the account is on the hook for in the pending set, matching
+			// upstream's pending-only accounting. totalcost covers sender-side obligations
+			// for this account's own txs; pendingGas covers gas this account owes as a fee
+			// payer for delegated txs.
 			obligation := new(big.Int)
 			if list := pool.pending[addr]; list != nil {
-				obligation.Add(obligation, list.totalvalue.ToBig())
-				obligation.Add(obligation, list.totalgas.ToBig())
+				// Sender-paid pending costs for txs sent by this account.
+				obligation.Add(obligation, list.totalcost.ToBig())
 			}
 			if g := pool.pendingGas[addr]; g != nil {
+				// Fee-delegated gas charged to this account as fee payer.
 				obligation.Add(obligation, g.ToBig())
 			}
 			return obligation

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1021,6 +1021,16 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 	}
 }
 
+func newPendingList(add, sub func(common.Address, *uint256.Int)) *list {
+	if add == nil || sub == nil {
+		panic("pending list requires both gas accounting callbacks")
+	}
+	l := newList(true)
+	l.addPendingGas = add
+	l.subPendingGas = sub
+	return l
+}
+
 // promoteTx adds a transaction to the pending (processable) list of transactions
 // and returns whether it was inserted or an older was better.
 //
@@ -1028,10 +1038,7 @@ func (pool *LegacyPool) journalTx(from common.Address, tx *types.Transaction) {
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		list := newList(true)
-		list.addPendingGas = pool.addPendingGas
-		list.subPendingGas = pool.subPendingGas
-		pool.pending[addr] = list
+		pool.pending[addr] = newPendingList(pool.addPendingGas, pool.subPendingGas)
 	}
 	list := pool.pending[addr]
 

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -659,6 +659,10 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 }
 
 func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int) {
+	if feeCost.IsZero() {
+		// Zero-cost removals are no-ops.
+		return
+	}
 	acc := pool.pendingGas[payer]
 	if acc == nil {
 		acc = new(uint256.Int)
@@ -668,6 +672,10 @@ func (pool *LegacyPool) addPendingGas(payer common.Address, feeCost *uint256.Int
 }
 
 func (pool *LegacyPool) subPendingGas(payer common.Address, feeCost *uint256.Int) {
+	if feeCost.IsZero() {
+		// Zero-cost removals are no-ops.
+		return
+	}
 	acc := pool.pendingGas[payer]
 	if acc == nil {
 		panic("pendingGas no entry for payer")
@@ -904,11 +912,12 @@ func (pool *LegacyPool) add(tx *types.Transaction, local bool) (replaced bool, e
 	// Try to replace an existing transaction in the pending pool
 	if list := pool.pending[from]; list != nil && list.Contains(tx.Nonce()) {
 		// Nonce already pending, check if required price bump is met
-		inserted, old := list.Add(tx, pool.config.PriceBump)
-		if !inserted {
+		old, err := list.Add(tx, pool.config.PriceBump)
+		if err != nil {
 			pendingDiscardMeter.Mark(1)
-			return false, txpool.ErrReplaceUnderpriced
+			return false, err
 		}
+
 		// New transaction is better, replace old one
 		if old != nil {
 			pool.all.Remove(old.Hash())
@@ -978,12 +987,12 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, local
 	if pool.queue[from] == nil {
 		pool.queue[from] = newList(false)
 	}
-	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump)
-	if !inserted {
-		// An older transaction was better, discard this
+	old, err := pool.queue[from].Add(tx, pool.config.PriceBump)
+	if err != nil {
 		queuedDiscardMeter.Mark(1)
-		return false, txpool.ErrReplaceUnderpriced
+		return false, err
 	}
+
 	// Discard any previous transaction and mark this
 	if old != nil {
 		pool.all.Remove(old.Hash())
@@ -1042,9 +1051,9 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 	}
 	list := pool.pending[addr]
 
-	inserted, old := list.Add(tx, pool.config.PriceBump)
-	if !inserted {
-		// An older transaction was better, discard this
+	old, err := list.Add(tx, pool.config.PriceBump)
+	if err != nil {
+		log.Error("Promoting invalid queued transaction", "hash", tx.Hash(), "err", err)
 		pool.all.Remove(hash)
 		pool.priced.Removed(1)
 		pendingDiscardMeter.Mark(1)

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3222,8 +3222,8 @@ func TestFeeDelegationCumulativeGas(t *testing.T) {
 	}
 
 	// Removing one accepted transaction frees enough of the fee payer's budget
-	// for the previously rejected one to be admitted, proving the index is also
-	// maintained on removal.
+	// for the previously rejected one to be admitted, proving the fee-payer gas
+	// accounting is also updated on removal.
 	pool.removeTx(txs[0].Hash(), false, true)
 	if err := pool.Add([]*types.Transaction{txs[2]}, true, true)[0]; err != nil {
 		t.Fatalf("tx 2 after removal: unexpected error: %v", err)
@@ -3319,13 +3319,23 @@ func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
 		gapTxs[i] = feeDelegateTx(chainID, 1, gas, gasFeeCap, gasTipCap, value, senders[i], feePayerKey)
 		fillTxs[i] = dynamicFeeTx(0, gas, gasFeeCap, gasTipCap, senders[i])
 	}
-
-	// All three fee-delegated txs have a nonce gap, so they sit in the queue. The
+	// All three nonce-1 fee-delegated txs have a nonce gap, so they sit in the queue. The
 	// per-fee-payer gas index only tracks pending txs, so each one passes the
 	// submission-time cumulative check in isolation (the index reads zero).
 	for i, tx := range gapTxs {
 		if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
 			t.Fatalf("gap tx %d: unexpected error: %v", i, err)
+		}
+	}
+	// Add a nonce tail for the third sender. These transactions also remain queued
+	// because nonce 0 is still missing.
+	tailTxs := types.Transactions{
+		feeDelegateTx(chainID, 2, gas, gasFeeCap, gasTipCap, value, senders[2], feePayerKey),
+		feeDelegateTx(chainID, 3, gas, gasFeeCap, gasTipCap, value, senders[2], feePayerKey),
+	}
+	for _, tx := range tailTxs {
+		if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
+			t.Fatalf("add tail tx nonce %d: %v", tx.Nonce(), err)
 		}
 	}
 	pool.mu.RLock()
@@ -3334,7 +3344,6 @@ func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
 		t.Fatalf("pendingGas[feePayer] = %v before promotion, want 0 (queued txs must not be tracked)", g)
 	}
 	pool.mu.RUnlock()
-
 	// Close each gap one sender at a time, so promotion is deterministic: the
 	// third sender's fee-delegated tx is the one that overdraws the fee payer.
 	for i, tx := range fillTxs {
@@ -3342,7 +3351,6 @@ func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
 			t.Fatalf("fill tx %d: unexpected error: %v", i, err)
 		}
 	}
-
 	// Exactly two fee-delegated txs must have been promoted to pending; the third
 	// fails the promotion-time cumulative check and is dropped with its nonce tail.
 	pool.mu.RLock()
@@ -3350,29 +3358,31 @@ func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
 	if g := pool.pendingGas[feePayer]; g != nil {
 		gotGas = g.ToBig()
 	}
-	promotedCount, droppedCount := 0, 0
-	for _, tx := range gapTxs {
-		if pool.all.Get(tx.Hash()) != nil {
-			promotedCount++
-		} else {
-			droppedCount++
-		}
-	}
-	if promotedCount != 2 || droppedCount != 1 {
-		t.Fatalf("want 2 promoted and 1 dropped")
-	}
-
 	feePayerBalance := pool.currentState.GetBalance(feePayer).ToBig()
 	pool.mu.RUnlock()
+	// The first two nonce-1 transactions must be pending.
+	for i := 0; i < 2; i++ {
+		if status := pool.Status(gapTxs[i].Hash()); status != txpool.TxStatusPending {
+			t.Fatalf("gap tx %d status = %v, want pending", i, status)
+		}
+	}
+
+	// The failed transaction and its nonce tail must be removed from the pool.
+	droppedTxs := append(types.Transactions{gapTxs[2]}, tailTxs...)
+	for _, tx := range droppedTxs {
+		if pool.Get(tx.Hash()) != nil {
+			t.Fatalf("tx nonce %d was not dropped", tx.Nonce())
+		}
+	}
 
 	if want := new(big.Int).Mul(perTxGas, big.NewInt(2)); gotGas.Cmp(want) != 0 {
 		t.Fatalf("pendingGas[feePayer] = %v after promotion, want %v", gotGas, want)
 	}
+
 	// The fee payer's aggregate gas obligation must never exceed its balance.
 	if gotGas.Cmp(feePayerBalance) > 0 {
 		t.Fatalf("pendingGas[feePayer] = %v exceeds balance %v", gotGas, feePayerBalance)
 	}
-
 	if err := validatePoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3280,3 +3280,272 @@ func TestPendingGasZeroAccounting(t *testing.T) {
 	}
 	pool.subPendingGas(payer, zero) // must not panic on the now-absent entry
 }
+
+// TestFeeDelegationCumulativeGasOnPromotion verifies that the cumulative fee
+// payer affordability check is also enforced when queued transactions are
+// promoted to the pending set, not only on submission. Queued (non-executable)
+// transactions are not tracked in the per-fee-payer gas index, so several of
+// them sharing one fee payer can each pass the submission-time check in
+// isolation; the promotion path must re-check the aggregate and reject the ones
+// that would overdraw the fee payer once they become executable together.
+func TestFeeDelegationCumulativeGasOnPromotion(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0) // enable fee delegation tx type
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gas = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	perTxGas := new(big.Int).Mul(big.NewInt(gas), gasFeeCap) // FeeCost per tx
+
+	// Fee payer can cover exactly two transactions' gas, not three.
+	feePayerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	testAddBalance(pool, feePayer, new(big.Int).Add(new(big.Int).Mul(perTxGas, big.NewInt(2)), new(big.Int).Div(perTxGas, big.NewInt(2))))
+
+	// Three distinct senders, each amply funded for a self-paid nonce-0 tx and a
+	// fee-delegated nonce-1 tx's value.
+	senders := make([]*ecdsa.PrivateKey, 3)
+	gapTxs := make([]*types.Transaction, 3)  // nonce 1, fee-delegated (fee payer pays gas)
+	fillTxs := make([]*types.Transaction, 3) // nonce 0, self-paid (closes the gap)
+	for i := range senders {
+		senders[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(senders[i].PublicKey), new(big.Int).Mul(perTxGas, big.NewInt(10)))
+		gapTxs[i] = feeDelegateTx(chainID, 1, gas, gasFeeCap, gasTipCap, value, senders[i], feePayerKey)
+		fillTxs[i] = dynamicFeeTx(0, gas, gasFeeCap, gasTipCap, senders[i])
+	}
+
+	// All three fee-delegated txs have a nonce gap, so they sit in the queue. The
+	// per-fee-payer gas index only tracks pending txs, so each one passes the
+	// submission-time cumulative check in isolation (the index reads zero).
+	for i, tx := range gapTxs {
+		if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
+			t.Fatalf("gap tx %d: unexpected error: %v", i, err)
+		}
+	}
+	pool.mu.RLock()
+	if g := pool.pendingGas[feePayer]; g != nil && !g.IsZero() {
+		pool.mu.RUnlock()
+		t.Fatalf("pendingGas[feePayer] = %v before promotion, want 0 (queued txs must not be tracked)", g)
+	}
+	pool.mu.RUnlock()
+
+	// Close each gap one sender at a time, so promotion is deterministic: the
+	// third sender's fee-delegated tx is the one that overdraws the fee payer.
+	for i, tx := range fillTxs {
+		if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
+			t.Fatalf("fill tx %d: unexpected error: %v", i, err)
+		}
+	}
+
+	// Exactly two fee-delegated txs must have been promoted to pending; the third
+	// fails the promotion-time cumulative check and is dropped with its nonce tail.
+	pool.mu.RLock()
+	gotGas := new(big.Int)
+	if g := pool.pendingGas[feePayer]; g != nil {
+		gotGas = g.ToBig()
+	}
+	promotedCount, droppedCount := 0, 0
+	for _, tx := range gapTxs {
+		if pool.all.Get(tx.Hash()) != nil {
+			promotedCount++
+		} else {
+			droppedCount++
+		}
+	}
+	if promotedCount != 2 || droppedCount != 1 {
+		t.Fatalf("want 2 promoted and 1 dropped")
+	}
+
+	feePayerBalance := pool.currentState.GetBalance(feePayer).ToBig()
+	pool.mu.RUnlock()
+
+	if want := new(big.Int).Mul(perTxGas, big.NewInt(2)); gotGas.Cmp(want) != 0 {
+		t.Fatalf("pendingGas[feePayer] = %v after promotion, want %v", gotGas, want)
+	}
+	// The fee payer's aggregate gas obligation must never exceed its balance.
+	if gotGas.Cmp(feePayerBalance) > 0 {
+		t.Fatalf("pendingGas[feePayer] = %v exceeds balance %v", gotGas, feePayerBalance)
+	}
+
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+	if err := validateFeeDelegationAccounting(pool); err != nil {
+		t.Fatalf("fee-delegation accounting drift: %v", err)
+	}
+}
+
+// validateFeeDelegationAccounting recomputes the fee-delegation accounting from
+// the live pending/queue contents and compares it against the maintained values.
+func validateFeeDelegationAccounting(pool *LegacyPool) error {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	wantPendingGas := make(map[common.Address]*big.Int)
+
+	// feeDelegated counter must match the number of FD txs held by every list.
+	countFD := func(l *list) int {
+		fd := 0
+		for _, tx := range l.txs.items {
+			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+				fd++
+			}
+		}
+		return fd
+	}
+
+	for addr, l := range pool.pending {
+		if fd := countFD(l); l.feeDelegated != fd {
+			return fmt.Errorf("pending[%s].feeDelegated = %d, recomputed %d", addr.Hex(), l.feeDelegated, fd)
+		}
+		sumCost := new(big.Int)
+		for _, tx := range l.txs.items {
+			if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+				sumCost.Add(sumCost, tx.Value())
+				p := *tx.FeePayer()
+				acc := wantPendingGas[p]
+				if acc == nil {
+					acc = new(big.Int)
+					wantPendingGas[p] = acc
+				}
+				acc.Add(acc, tx.FeeCost())
+			} else {
+				sumCost.Add(sumCost, tx.Cost())
+			}
+		}
+		if l.totalcost.ToBig().Cmp(sumCost) != 0 {
+			return fmt.Errorf("pending[%s].totalcost = %v, recomputed %v", addr.Hex(), l.totalcost, sumCost)
+		}
+	}
+	for addr, l := range pool.queue {
+		if fd := countFD(l); l.feeDelegated != fd {
+			return fmt.Errorf("queue[%s].feeDelegated = %d, recomputed %d", addr.Hex(), l.feeDelegated, fd)
+		}
+	}
+	// pendingGas[payer] must equal the summed FeeCost of pending FD txs charging
+	// it. A zero sum must have no entry (addPendingGas skips zero contributions).
+	for payer, want := range wantPendingGas {
+		got := pool.pendingGas[payer]
+		if want.Sign() == 0 {
+			if got != nil {
+				return fmt.Errorf("pendingGas[%s] = %v, want no entry (zero obligation)", payer.Hex(), got)
+			}
+			continue
+		}
+		if got == nil || got.ToBig().Cmp(want) != 0 {
+			return fmt.Errorf("pendingGas[%s] = %v, recomputed %v", payer.Hex(), got, want)
+		}
+	}
+	for payer, got := range pool.pendingGas {
+		if wantPendingGas[payer] == nil && !got.IsZero() {
+			return fmt.Errorf("pendingGas[%s] = %v but no pending FD tx charges it", payer.Hex(), got)
+		}
+	}
+	return nil
+}
+
+// TestListFeeDelegatedCounter verifies that the per-list feeDelegated counter is
+// kept in sync across adds, fee-delegated replacements (subtract old + add new),
+// and removals routed through subCosts.
+func TestListFeeDelegatedCounter(t *testing.T) {
+	t.Parallel()
+
+	chainID := params.TestChainConfig.ChainID
+	senderKey, _ := crypto.GenerateKey()
+	payerKey, _ := crypto.GenerateKey()
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+
+	l := newList(false)
+	l.Add(dynamicFeeTx(0, 21000, gasFeeCap, gasTipCap, senderKey), DefaultConfig.PriceBump)
+	l.Add(feeDelegateTx(chainID, 1, 21000, gasFeeCap, gasTipCap, big.NewInt(1), senderKey, payerKey), DefaultConfig.PriceBump)
+	l.Add(feeDelegateTx(chainID, 2, 21000, gasFeeCap, gasTipCap, big.NewInt(1), senderKey, payerKey), DefaultConfig.PriceBump)
+	if l.feeDelegated != 2 {
+		t.Fatalf("feeDelegated = %d after adds, want 2", l.feeDelegated)
+	}
+
+	// Replace the nonce-1 FD tx with a higher-priced FD tx: net counter change 0.
+	higher := feeDelegateTx(chainID, 1, 21000, big.NewInt(2_000_000_000), big.NewInt(2), big.NewInt(1), senderKey, payerKey)
+	if _, err := l.Add(higher, DefaultConfig.PriceBump); err != nil {
+		t.Fatalf("replacement add: %v", err)
+	}
+	if l.feeDelegated != 2 {
+		t.Fatalf("feeDelegated = %d after FD->FD replacement, want 2", l.feeDelegated)
+	}
+
+	// Forward(2) removes nonces 0 (normal) and 1 (FD); the counter drops by one.
+	l.Forward(2)
+	if l.feeDelegated != 1 {
+		t.Fatalf("feeDelegated = %d after Forward(2), want 1", l.feeDelegated)
+	}
+}
+
+// TestFeeDelegationFilterShortCircuitGate verifies that a pending fee-delegated
+// transaction whose fee payer became insolvent is demoted even when the sender's
+// balance still covers the cached cost cap. Without the feeDelegated gate the
+// Filter short-circuit (keyed on the sender balance) would skip the per-tx
+// fee-payer balance check and leave the unpayable tx pending.
+func TestFeeDelegationFilterShortCircuitGate(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0)
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gasLimit = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	feeCost := new(big.Int).Mul(big.NewInt(gasLimit), gasFeeCap)
+
+	senderKey, _ := crypto.GenerateKey()
+	sender := crypto.PubkeyToAddress(senderKey.PublicKey)
+	payerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(payerKey.PublicKey)
+
+	// Sender holds far more than tx.Cost() (value + gas), so the Filter cost/gas
+	// short-circuit would skip the per-tx fee-payer check without the gate. The
+	// fee payer is funded for exactly one transaction's gas.
+	testAddBalance(pool, sender, new(big.Int).Mul(feeCost, big.NewInt(100)))
+	testAddBalance(pool, feePayer, feeCost)
+
+	tx := feeDelegateTx(chainID, 0, gasLimit, gasFeeCap, gasTipCap, value, senderKey, payerKey)
+	if err := pool.Add([]*types.Transaction{tx}, true, true)[0]; err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	pool.mu.RLock()
+	inPending := pool.pending[sender] != nil && pool.pending[sender].txs.Get(0) != nil
+	pool.mu.RUnlock()
+	if !inPending {
+		t.Fatalf("fee-delegated tx was not promoted to pending")
+	}
+
+	// Drain the fee payer below its FeeCost; the sender balance stays high.
+	testAddBalance(pool, feePayer, new(big.Int).Neg(feeCost))
+
+	pool.mu.Lock()
+	pool.demoteUnexecutables()
+	pool.mu.Unlock()
+
+	pool.mu.RLock()
+	stillPending := pool.pending[sender] != nil && pool.pending[sender].txs.Get(0) != nil
+	pg := pool.pendingGas[feePayer]
+	pool.mu.RUnlock()
+	if stillPending {
+		t.Fatalf("insolvent fee-payer tx still pending; Filter short-circuit gate not working")
+	}
+	if pg != nil && !pg.IsZero() {
+		t.Fatalf("pendingGas[feePayer] = %v after demote, want 0", pg)
+	}
+	if err := validateFeeDelegationAccounting(pool); err != nil {
+		t.Fatalf("fee-delegation accounting drift: %v", err)
+	}
+}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3137,3 +3137,98 @@ func BenchmarkMultiAccountBatchInsert(b *testing.B) {
 		pool.addRemotesSync([]*types.Transaction{tx})
 	}
 }
+
+// feeDelegateTx builds a fee delegation dynamic-fee transaction signed by both
+// the sender (over the inner DynamicFeeTx) and the fee payer (over the wrapping
+// FeeDelegateDynamicFeeTx).
+func feeDelegateTx(chainID *big.Int, nonce uint64, gas uint64, gasFeeCap, gasTipCap, value *big.Int, senderKey, feePayerKey *ecdsa.PrivateKey) *types.Transaction {
+	to := common.Address{}
+	inner := types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+		Gas:       gas,
+		To:        &to,
+		Value:     value,
+	}
+	signedSender := types.MustSignNewTx(senderKey, types.LatestSignerForChainID(chainID), &inner)
+	v, r, s := signedSender.RawSignatureValues()
+	inner.V, inner.R, inner.S = v, r, s
+
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	fd := &types.FeeDelegateDynamicFeeTx{FeePayer: &feePayer}
+	fd.SetSenderTx(inner)
+	return types.MustSignNewTx(feePayerKey, types.NewFeeDelegateSigner(chainID), fd)
+}
+
+// TestFeeDelegationCumulativeGas verifies that the pool aggregates the gas
+// obligations of fee delegation transactions per fee payer across the many
+// sender lists it subsidises, and rejects new transactions once that aggregate
+// would overdraw the fee payer's balance, while leaving the per-sender value
+// accounting intact.
+func TestFeeDelegationCumulativeGas(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0) // enable fee delegation tx type
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	chainID := config.ChainID
+	const gas = 21000
+	gasFeeCap := big.NewInt(1_000_000_000)
+	gasTipCap := big.NewInt(1)
+	value := big.NewInt(100)
+	perTxGas := new(big.Int).Mul(big.NewInt(gas), gasFeeCap) // FeeCost per tx
+
+	// Fee payer can cover exactly two transactions' gas, not three.
+	feePayerKey, _ := crypto.GenerateKey()
+	feePayer := crypto.PubkeyToAddress(feePayerKey.PublicKey)
+	testAddBalance(pool, feePayer, new(big.Int).Add(new(big.Int).Mul(perTxGas, big.NewInt(2)), new(big.Int).Div(perTxGas, big.NewInt(2))))
+
+	// Three distinct senders, each amply funded for their own value transfer.
+	senders := make([]*ecdsa.PrivateKey, 3)
+	txs := make([]*types.Transaction, 3)
+	for i := range senders {
+		senders[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(senders[i].PublicKey), big.NewInt(1_000_000))
+		txs[i] = feeDelegateTx(chainID, 0, gas, gasFeeCap, gasTipCap, value, senders[i], feePayerKey)
+	}
+
+	// First two transactions fit within the fee payer's balance.
+	if err := pool.Add([]*types.Transaction{txs[0]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 0: unexpected error: %v", err)
+	}
+	if err := pool.Add([]*types.Transaction{txs[1]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 1: unexpected error: %v", err)
+	}
+
+	// The pool-wide gas index must now reflect both transactions' fees.
+	pool.mu.RLock()
+	gotGas := new(big.Int)
+	if g := pool.pendingGas[feePayer]; g != nil {
+		gotGas = g.ToBig()
+	}
+	pool.mu.RUnlock()
+	if want := new(big.Int).Mul(perTxGas, big.NewInt(2)); gotGas.Cmp(want) != 0 {
+		t.Fatalf("pendingGas[feePayer] = %v, want %v", gotGas, want)
+	}
+
+	// The third transaction is individually affordable, but pushes the fee
+	// payer's aggregate gas obligation over its balance and must be rejected.
+	if err := pool.Add([]*types.Transaction{txs[2]}, true, true)[0]; !errors.Is(err, txpool.ErrFeePayerInsufficientFunds) {
+		t.Fatalf("tx 2: error = %v, want %v", err, txpool.ErrFeePayerInsufficientFunds)
+	}
+
+	// Removing one accepted transaction frees enough of the fee payer's budget
+	// for the previously rejected one to be admitted, proving the index is also
+	// maintained on removal.
+	pool.removeTx(txs[0].Hash(), false, true)
+	if err := pool.Add([]*types.Transaction{txs[2]}, true, true)[0]; err != nil {
+		t.Fatalf("tx 2 after removal: unexpected error: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -3232,3 +3232,51 @@ func TestFeeDelegationCumulativeGas(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 }
+
+// TestPendingGasZeroAccounting verifies that fee-delegated transactions whose gas
+// obligation is zero (e.g. a zero gas-fee-cap tx) do not corrupt the pool-wide
+// per-fee-payer gas index. addPendingGas creates an entry on first use and
+// subPendingGas deletes it once it reaches zero and panics on a missing one, so a
+// naive implementation would: create a zero entry, delete it on the first
+// removal, then panic on the second removal of another zero-gas tx sharing the
+// fee payer. The accounting must skip zero contributions symmetrically instead.
+func TestPendingGasZeroAccounting(t *testing.T) {
+	t.Parallel()
+
+	config := *params.TestChainConfig
+	config.ApplepieBlock = big.NewInt(0)
+	pool, _ := setupPoolWithConfig(&config)
+	defer pool.Close()
+
+	payerKey, _ := crypto.GenerateKey()
+	payer := crypto.PubkeyToAddress(payerKey.PublicKey)
+	zero := new(uint256.Int)
+	five := uint256.NewInt(5)
+
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	// Two zero-gas obligations sharing a fee payer: the second removal must not
+	// panic on a missing map entry.
+	pool.addPendingGas(payer, zero)
+	pool.addPendingGas(payer, zero)
+	if _, ok := pool.pendingGas[payer]; ok {
+		t.Fatalf("zero gas obligation must not create a pendingGas entry")
+	}
+	pool.subPendingGas(payer, zero)
+	pool.subPendingGas(payer, zero)
+
+	// Mixed: a real obligation kept alongside a zero one. Removing the real one
+	// first drives the running total to zero and deletes the entry; the later
+	// zero removal must still be a no-op rather than a panic.
+	pool.addPendingGas(payer, five)
+	pool.addPendingGas(payer, zero)
+	if got := pool.pendingGas[payer]; got == nil || got.Cmp(five) != 0 {
+		t.Fatalf("pendingGas[payer] = %v, want %v", got, five)
+	}
+	pool.subPendingGas(payer, five)
+	if _, ok := pool.pendingGas[payer]; ok {
+		t.Fatalf("pendingGas entry must be deleted once it reaches zero")
+	}
+	pool.subPendingGas(payer, zero) // must not panic on the now-absent entry
+}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -494,10 +494,12 @@ func (l *list) subCosts(txs []*types.Transaction) {
 // state is treated as a fatal wiring bug and panics. Used as the top-level guard
 // in addCost/subCost so both stay symmetric.
 func (l *list) tracksExpenditure() bool {
-	if (l.addPendingGas == nil) != (l.subPendingGas == nil) {
-		panic("legacypool: inconsistent pendingGas callbacks would corrupt gas accounting ")
+	hasAddPendingGas := l.addPendingGas != nil
+	hasSubPendingGas := l.subPendingGas != nil
+	if hasAddPendingGas != hasSubPendingGas {
+		panic("inconsistent pendingGas callbacks would corrupt gas accounting")
 	}
-	return l.addPendingGas != nil
+	return hasAddPendingGas
 }
 
 // addCost updates the expenditure counters used by pending-only overdraft

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
 )
 
@@ -274,19 +275,36 @@ type list struct {
 	strict bool       // Whether nonces are strictly continuous or not
 	txs    *sortedMap // Heap indexed sorted hash map of the transactions
 
-	costcap   *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
-	gascap    uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
-	totalcost *uint256.Int // Total cost of all transactions in the list
+	costcap *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
+	gascap  uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
+
+	// totalvalue is the cumulative tx.Value() of every transaction in the list,
+	// i.e. the amount this account owes purely as a *sender* (regardless of who
+	// pays the gas). Used for the cumulative overdraft check.
+	totalvalue *uint256.Int
+
+	// totalgas is the cumulative gas-side cost (tx.FeeCost()) of the transactions
+	// in this list for which this account is also the gas payer, i.e. every
+	// non-fee-delegated transaction. Gas owed via fee delegation is attributed to
+	// the fee payer through pendingGas instead, since that account may not have a
+	// list of its own.
+	totalgas *uint256.Int
+
+	// addPendingGas and subPendingGas update pool-wide fee-payer gas accounting
+	// for fee-delegated transactions in pending lists.
+	addPendingGas func(common.Address, *uint256.Int)
+	subPendingGas func(common.Address, *uint256.Int)
 }
 
 // newList creates a new transaction list for maintaining nonce-indexable fast,
 // gapped, sortable transaction lists.
 func newList(strict bool) *list {
 	return &list{
-		strict:    strict,
-		txs:       newSortedMap(),
-		costcap:   new(uint256.Int),
-		totalcost: new(uint256.Int),
+		strict:     strict,
+		txs:        newSortedMap(),
+		costcap:    new(uint256.Int),
+		totalvalue: new(uint256.Int),
+		totalgas:   new(uint256.Int),
 	}
 }
 
@@ -325,14 +343,14 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 			return false, nil
 		}
 		// Old is being replaced, subtract old cost
-		l.subTotalCost([]*types.Transaction{old})
+		l.subCosts([]*types.Transaction{old})
 	}
-	// Add new tx cost to totalcost
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
 		return false, nil
 	}
-	l.totalcost.Add(l.totalcost, cost)
+
+	l.addCost(tx)
 
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
@@ -350,7 +368,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 // maintenance.
 func (l *list) Forward(threshold uint64) types.Transactions {
 	txs := l.txs.Forward(threshold)
-	l.subTotalCost(txs)
+	l.subCosts(txs)
 	return txs
 }
 
@@ -393,9 +411,8 @@ func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uin
 		}
 		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
 	}
-	// Reset total cost
-	l.subTotalCost(removed)
-	l.subTotalCost(invalids)
+	l.subCosts(removed)
+	l.subCosts(invalids)
 	l.txs.reheap()
 	return removed, invalids
 }
@@ -404,7 +421,7 @@ func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uin
 // exceeding that limit.
 func (l *list) Cap(threshold int) types.Transactions {
 	txs := l.txs.Cap(threshold)
-	l.subTotalCost(txs)
+	l.subCosts(txs)
 	return txs
 }
 
@@ -417,11 +434,11 @@ func (l *list) Remove(tx *types.Transaction) (bool, types.Transactions) {
 	if removed := l.txs.Remove(nonce); !removed {
 		return false, nil
 	}
-	l.subTotalCost([]*types.Transaction{tx})
+	l.subCosts([]*types.Transaction{tx})
 	// In strict mode, filter out non-executable transactions
 	if l.strict {
 		txs := l.txs.Filter(func(tx *types.Transaction) bool { return tx.Nonce() > nonce })
-		l.subTotalCost(txs)
+		l.subCosts(txs)
 		return true, txs
 	}
 	return true, nil
@@ -436,7 +453,7 @@ func (l *list) Remove(tx *types.Transaction) (bool, types.Transactions) {
 // happen but better to be self correcting than failing!
 func (l *list) Ready(start uint64) types.Transactions {
 	txs := l.txs.Ready(start)
-	l.subTotalCost(txs)
+	l.subCosts(txs)
 	return txs
 }
 
@@ -463,14 +480,68 @@ func (l *list) LastElement() *types.Transaction {
 	return l.txs.LastElement()
 }
 
-// subTotalCost subtracts the cost of the given transactions from the
-// total cost of all transactions.
-func (l *list) subTotalCost(txs []*types.Transaction) {
+// subCosts applies subCost to each of the given transactions.
+func (l *list) subCosts(txs []*types.Transaction) {
 	for _, tx := range txs {
-		_, underflow := l.totalcost.SubOverflow(l.totalcost, uint256.MustFromBig(tx.Cost()))
-		if underflow {
-			panic("totalcost underflow")
+		l.subCost(tx)
+	}
+}
+
+// tracksExpenditure reports whether this list is wired for the pool-wide fee-payer
+// gas accounting (pending lists are; queue/test lists are not). The two callbacks
+// are always set as a pair — if only one were nil, addCost/subCost would diverge
+// and the accounting (totalvalue/pendingGas) would become wrong, so a half-wired
+// state is treated as a fatal wiring bug and panics. Used as the top-level guard
+// in addCost/subCost so both stay symmetric.
+func (l *list) tracksExpenditure() bool {
+	if (l.addPendingGas == nil) != (l.subPendingGas == nil) {
+		panic("legacypool: inconsistent pendingGas callbacks would corrupt gas accounting ")
+	}
+	return l.addPendingGas != nil
+}
+
+// addCost updates the expenditure counters used by pending-only overdraft
+// accounting. Lists without pending-gas callbacks are unwired queue/test lists;
+// their counters are intentionally unused by ExistingExpenditure, so value and
+// gas are skipped together.
+func (l *list) addCost(tx *types.Transaction) {
+	if !l.tracksExpenditure() {
+		return
+	}
+	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
+
+	feeCost := uint256.MustFromBig(tx.FeeCost())
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		if tx.FeePayer() == nil {
+			log.Error("fee-delegated tx missing fee payer in addCost", "tx", tx.Hash())
+			return
 		}
+		l.addPendingGas(*tx.FeePayer(), feeCost)
+		return
+	}
+	l.totalgas.Add(l.totalgas, feeCost)
+}
+
+// subCost reverses addCost for a removed transaction.
+func (l *list) subCost(tx *types.Transaction) {
+	if !l.tracksExpenditure() {
+		return
+	}
+	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
+		panic("totalvalue underflow")
+	}
+
+	feeCost := uint256.MustFromBig(tx.FeeCost())
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		if tx.FeePayer() == nil {
+			log.Error("fee-delegated tx missing fee payer in subCost", "tx", tx.Hash())
+			return
+		}
+		l.subPendingGas(*tx.FeePayer(), feeCost)
+		return
+	}
+	if _, underflow := l.totalgas.SubOverflow(l.totalgas, feeCost); underflow {
+		panic("totalgas underflow")
 	}
 }
 

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -309,7 +309,7 @@ func (l *list) Contains(nonce uint64) bool {
 }
 
 // Add tries to insert a new transaction into the list, returning any previous
-// transaction it replaced, or an error if the transaction was rejected
+// transaction it replaced, or an error if the transaction was rejected.
 //
 // If the new transaction is accepted into the list, the list's cost and gas
 // thresholds and expenditure accounting are also potentially updated.
@@ -387,7 +387,7 @@ func (l *list) Forward(threshold uint64) types.Transactions {
 // For fee-delegated transactions, the sender must cover tx.Value(), the fee
 // payer must cover tx.FeeCost(), and tx.Gas() must fit within the block gas limit.
 func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uint256.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
-	// Short circuit only when every tx is below the thresholds AND the list holds
+	// Short circuit only when every tx is below the thresholds and the list holds
 	// no fee-delegated tx (the cap check ignores the fee-payer balance dimension).
 	if l.feeDelegated == 0 && l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
 		return nil, nil
@@ -504,7 +504,7 @@ func (l *list) decFeeDelegated(tx *types.Transaction) {
 	}
 }
 
-// subCosts reverses pending expenditure accounting for removed txs.
+// subCosts reverses fee-delegation counters and pending expenditure accounting for removed txs.
 func (l *list) subCosts(txs []*types.Transaction) {
 	for _, tx := range txs {
 		l.decFeeDelegated(tx)

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
 )
 
@@ -314,17 +314,23 @@ func (l *list) Contains(nonce uint64) bool {
 	return l.txs.Get(nonce) != nil
 }
 
-// Add tries to insert a new transaction into the list, returning whether the
-// transaction was accepted, and if yes, any previous transaction it replaced.
-//
-// If the new transaction is accepted into the list, the lists' cost and gas
-// thresholds are also potentially updated.
-func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transaction) {
+// Add tries to insert a new transaction into the list, returning any previous
+// transaction it replaced, or an error if the transaction was rejected (e.g.
+// underpriced replacement or invalid fee payer). On success, the list updates
+// its cost/gas thresholds and expenditure accounting (totalvalue, totalgas,
+// and pool-wide pendingGas for fee-delegated transactions).
+func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction, error) {
+	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
+	// unreachable on the normal path. Keep the invariant local to list.Add too.
+	// if it ever were reached, the caller may surface this as ErrReplaceUnderpriced (when colliding on nonce)
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
+		return nil, txpool.ErrInvalidFeePayer
+	}
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
 		if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
-			return false, nil
+			return nil, txpool.ErrReplaceUnderpriced
 		}
 		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
 		a := big.NewInt(100 + int64(priceBump))
@@ -340,18 +346,18 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		// old ones as well as checking the percentage threshold to ensure that
 		// this is accurate for low (Wei-level) gas price replacements.
 		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
-			return false, nil
+			return nil, txpool.ErrReplaceUnderpriced
 		}
 		// Old is being replaced, subtract old cost
 		l.subCosts([]*types.Transaction{old})
 	}
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {
-		return false, nil
+		return nil, txpool.ErrReplaceUnderpriced
 	}
-
-	l.addCost(tx)
-
+	if err := l.addCost(tx); err != nil {
+		return nil, err
+	}
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
 	if l.costcap.Cmp(cost) < 0 {
@@ -360,7 +366,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 	if gas := tx.Gas(); l.gascap < gas {
 		l.gascap = gas
 	}
-	return true, old
+	return old, nil
 }
 
 // Forward removes all transactions from the list with a nonce lower than the
@@ -506,22 +512,21 @@ func (l *list) tracksExpenditure() bool {
 // accounting. Lists without pending-gas callbacks are unwired queue/test lists;
 // their counters are intentionally unused by ExistingExpenditure, so value and
 // gas are skipped together.
-func (l *list) addCost(tx *types.Transaction) {
+func (l *list) addCost(tx *types.Transaction) error {
 	if !l.tracksExpenditure() {
-		return
+		return nil
+	}
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
+		return txpool.ErrInvalidFeePayer
 	}
 	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
-
 	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		if tx.FeePayer() == nil {
-			log.Error("fee-delegated tx missing fee payer in addCost", "tx", tx.Hash())
-			return
-		}
 		l.addPendingGas(*tx.FeePayer(), feeCost)
-		return
+		return nil
 	}
 	l.totalgas.Add(l.totalgas, feeCost)
+	return nil
 }
 
 // subCost reverses addCost for a removed transaction.
@@ -529,16 +534,14 @@ func (l *list) subCost(tx *types.Transaction) {
 	if !l.tracksExpenditure() {
 		return
 	}
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
+		panic("fee-delegated tx missing fee payer in subCost")
+	}
 	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
 		panic("totalvalue underflow")
 	}
-
 	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		if tx.FeePayer() == nil {
-			log.Error("fee-delegated tx missing fee payer in subCost", "tx", tx.Hash())
-			return
-		}
 		l.subPendingGas(*tx.FeePayer(), feeCost)
 		return
 	}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -311,9 +311,8 @@ func (l *list) Contains(nonce uint64) bool {
 // If the new transaction is accepted into the list, the list's cost and gas
 // thresholds and expenditure accounting are also potentially updated.
 func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction, error) {
-	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
-	// unreachable on the normal path. Keep the invariant local to list.Add too.
-	// if it ever were reached, the caller may surface this as ErrReplaceUnderpriced (when colliding on nonce)
+	// ValidateTransaction rejects fee-delegated txs without a fee payer before they
+	// reach the list. Check again here because addCost/subCost dereference FeePayer.
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		return nil, txpool.ErrInvalidFeePayer
 	}
@@ -484,12 +483,9 @@ func (l *list) subCosts(txs []*types.Transaction) {
 	}
 }
 
-// tracksExpenditure reports whether this list is wired for the pool-wide fee-payer
-// gas accounting (pending lists are; queue/test lists are not). The two callbacks
-// are always set as a pair — if only one were nil, addCost/subCost would diverge
-// and the accounting (totalvalue/pendingGas) would become wrong, so a half-wired
-// state is treated as a fatal wiring bug and panics. Used as the top-level guard
-// in addCost/subCost so both stay symmetric.
+// tracksExpenditure reports whether this list participates in pending
+// expenditure accounting. The pendingGas callbacks must be wired as a pair so
+// addCost/subCost remain symmetric.
 func (l *list) tracksExpenditure() bool {
 	hasAddPendingGas := l.addPendingGas != nil
 	hasSubPendingGas := l.subPendingGas != nil
@@ -499,10 +495,9 @@ func (l *list) tracksExpenditure() bool {
 	return hasAddPendingGas
 }
 
-// addCost updates the expenditure counters used by pending-only overdraft
-// accounting. Lists without pending-gas callbacks are unwired queue/test lists;
-// their counters are intentionally unused by ExistingExpenditure, so value and
-// gas are skipped together.
+// addCost updates pending-only expenditure accounting: totalcost for sender-side
+// obligations and pendingGas for fee-payer gas. Queue/test lists are not wired
+// into ExistingExpenditure, so they skip this accounting entirely.
 func (l *list) addCost(tx *types.Transaction) error {
 	if !l.tracksExpenditure() {
 		return nil

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -278,17 +278,9 @@ type list struct {
 	costcap *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
 	gascap  uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
 
-	// totalvalue is the cumulative tx.Value() of every transaction in the list,
-	// i.e. the amount this account owes purely as a *sender* (regardless of who
-	// pays the gas). Used for the cumulative overdraft check.
-	totalvalue *uint256.Int
-
-	// totalgas is the cumulative gas-side cost (tx.FeeCost()) of the transactions
-	// in this list for which this account is also the gas payer, i.e. every
-	// non-fee-delegated transaction. Gas owed via fee delegation is attributed to
-	// the fee payer through pendingGas instead, since that account may not have a
-	// list of its own.
-	totalgas *uint256.Int
+	// totalcost tracks the sender-side pending cost:
+	// tx.Cost() for non-fee-delegated txs, tx.Value() for fee-delegated txs.
+	totalcost *uint256.Int
 
 	// addPendingGas and subPendingGas update pool-wide fee-payer gas accounting
 	// for fee-delegated transactions in pending lists.
@@ -300,11 +292,10 @@ type list struct {
 // gapped, sortable transaction lists.
 func newList(strict bool) *list {
 	return &list{
-		strict:     strict,
-		txs:        newSortedMap(),
-		costcap:    new(uint256.Int),
-		totalvalue: new(uint256.Int),
-		totalgas:   new(uint256.Int),
+		strict:    strict,
+		txs:       newSortedMap(),
+		costcap:   new(uint256.Int),
+		totalcost: new(uint256.Int),
 	}
 }
 
@@ -315,10 +306,10 @@ func (l *list) Contains(nonce uint64) bool {
 }
 
 // Add tries to insert a new transaction into the list, returning any previous
-// transaction it replaced, or an error if the transaction was rejected (e.g.
-// underpriced replacement or invalid fee payer). On success, the list updates
-// its cost/gas thresholds and expenditure accounting (totalvalue, totalgas,
-// and pool-wide pendingGas for fee-delegated transactions).
+// transaction it replaced, or an error if the transaction was rejected
+//
+// If the new transaction is accepted into the list, the list's cost and gas
+// thresholds and expenditure accounting are also potentially updated.
 func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction, error) {
 	// The upstream ValidateTransaction already rejects these (ErrInvalidFeePayer), so this is
 	// unreachable on the normal path. Keep the invariant local to list.Add too.
@@ -486,7 +477,7 @@ func (l *list) LastElement() *types.Transaction {
 	return l.txs.LastElement()
 }
 
-// subCosts applies subCost to each of the given transactions.
+// subCosts reverses pending expenditure accounting for removed txs.
 func (l *list) subCosts(txs []*types.Transaction) {
 	for _, tx := range txs {
 		l.subCost(tx)
@@ -519,13 +510,12 @@ func (l *list) addCost(tx *types.Transaction) error {
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		return txpool.ErrInvalidFeePayer
 	}
-	l.totalvalue.Add(l.totalvalue, uint256.MustFromBig(tx.Value()))
-	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		l.addPendingGas(*tx.FeePayer(), feeCost)
+		l.totalcost.Add(l.totalcost, uint256.MustFromBig(tx.Value()))
+		l.addPendingGas(*tx.FeePayer(), uint256.MustFromBig(tx.FeeCost()))
 		return nil
 	}
-	l.totalgas.Add(l.totalgas, feeCost)
+	l.totalcost.Add(l.totalcost, uint256.MustFromBig(tx.Cost()))
 	return nil
 }
 
@@ -537,16 +527,15 @@ func (l *list) subCost(tx *types.Transaction) {
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		panic("fee-delegated tx missing fee payer in subCost")
 	}
-	if _, underflow := l.totalvalue.SubOverflow(l.totalvalue, uint256.MustFromBig(tx.Value())); underflow {
-		panic("totalvalue underflow")
-	}
-	feeCost := uint256.MustFromBig(tx.FeeCost())
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
-		l.subPendingGas(*tx.FeePayer(), feeCost)
+		if _, underflow := l.totalcost.SubOverflow(l.totalcost, uint256.MustFromBig(tx.Value())); underflow {
+			panic("totalcost underflow")
+		}
+		l.subPendingGas(*tx.FeePayer(), uint256.MustFromBig(tx.FeeCost()))
 		return
 	}
-	if _, underflow := l.totalgas.SubOverflow(l.totalgas, feeCost); underflow {
-		panic("totalgas underflow")
+	if _, underflow := l.totalcost.SubOverflow(l.totalcost, uint256.MustFromBig(tx.Cost())); underflow {
+		panic("totalcost underflow")
 	}
 }
 

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -282,6 +282,9 @@ type list struct {
 	// tx.Cost() for non-fee-delegated txs, tx.Value() for fee-delegated txs.
 	totalcost *uint256.Int
 
+	// feeDelegated counts the fee-delegated transactions currently held.
+	feeDelegated int
+
 	// addPendingGas and subPendingGas update pool-wide fee-payer gas accounting
 	// for fee-delegated transactions in pending lists.
 	addPendingGas func(common.Address, *uint256.Int)
@@ -316,6 +319,12 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction,
 	if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() == nil {
 		return nil, txpool.ErrInvalidFeePayer
 	}
+	// Reject overflow before mutating accounting, otherwise a failed replacement
+	// could leave the old transaction in the map but missing from the counters.
+	cost, overflow := uint256.FromBig(tx.Cost())
+	if overflow {
+		return nil, txpool.ErrReplaceUnderpriced
+	}
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
@@ -341,15 +350,12 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (*types.Transaction,
 		// Old is being replaced, subtract old cost
 		l.subCosts([]*types.Transaction{old})
 	}
-	cost, overflow := uint256.FromBig(tx.Cost())
-	if overflow {
-		return nil, txpool.ErrReplaceUnderpriced
-	}
 	if err := l.addCost(tx); err != nil {
 		return nil, err
 	}
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
+	l.incFeeDelegated(tx)
 	if l.costcap.Cmp(cost) < 0 {
 		l.costcap = cost
 	}
@@ -373,13 +379,17 @@ func (l *list) Forward(threshold uint64) types.Transactions {
 // post-removal maintenance. Strict-mode invalidated transactions are also
 // returned.
 //
-// This method uses the cached costcap and gascap to quickly decide if there's even
-// a point in calculating all the costs or if the balance covers all. If the threshold
-// is lower than the costgas cap, the caps will be reset to a new high after removing
-// the newly invalidated transactions.
+// The cached costcap/gascap allow a quick short-circuit when the sender balance
+// and block gas limit cover every transaction. This shortcut is disabled while
+// the list holds any fee-delegated tx, because costcap cannot represent the
+// separate fee-payer balance dimension.
+//
+// For fee-delegated transactions, the sender must cover tx.Value(), the fee
+// payer must cover tx.FeeCost(), and tx.Gas() must fit within the block gas limit.
 func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uint256.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
-	// If all transactions are below the threshold, short circuit
-	if l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
+	// Short circuit only when every tx is below the thresholds AND the list holds
+	// no fee-delegated tx (the cap check ignores the fee-payer balance dimension).
+	if l.feeDelegated == 0 && l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
 		return nil, nil
 	}
 	l.costcap = new(uint256.Int).Set(costLimit) // Lower the caps to the thresholds
@@ -388,7 +398,11 @@ func (l *list) Filter(feeDelegation bool, stateDB *state.StateDB, costLimit *uin
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
 		if feeDelegation && tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
-			return tx.Gas() > gasLimit || tx.FeeCost().Cmp(stateDB.GetBalance(*tx.FeePayer()).ToBig()) > 0 || tx.Value().Cmp(costLimit.ToBig()) > 0
+			// Sender owes the value, the gas must fit the block, and the fee payer
+			// must cover the gas cost.
+			return tx.Gas() > gasLimit ||
+				tx.Value().Cmp(costLimit.ToBig()) > 0 ||
+				tx.FeeCost().Cmp(stateDB.GetBalance(*tx.FeePayer()).ToBig()) > 0
 		}
 		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit.ToBig()) > 0
 	})
@@ -476,9 +490,24 @@ func (l *list) LastElement() *types.Transaction {
 	return l.txs.LastElement()
 }
 
+func (l *list) incFeeDelegated(tx *types.Transaction) {
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		l.feeDelegated++
+	}
+}
+func (l *list) decFeeDelegated(tx *types.Transaction) {
+	if tx.Type() == types.FeeDelegateDynamicFeeTxType {
+		l.feeDelegated--
+		if l.feeDelegated < 0 {
+			panic("feeDelegated counter underflow")
+		}
+	}
+}
+
 // subCosts reverses pending expenditure accounting for removed txs.
 func (l *list) subCosts(txs []*types.Transaction) {
 	for _, tx := range txs {
+		l.decFeeDelegated(tx)
 		l.subCost(tx)
 	}
 }

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -298,7 +298,7 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		txGasCost := tx.FeeCost() // tx.Cost() - tx.Value()
 
 		// If a transaction with the same sender and nonce is already pooled, the
-		// incoming one replaces it, so its contribution must be discounted from
+		// incoming one replaces it, so its contribution must be subtracted from
 		// whichever account currently carries it (value -> sender, gas -> its own
 		// gas payer, which may differ from the new transaction's gas payer).
 		var (

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -320,7 +320,7 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 			// Pools without fee-delegation support (e.g. the blob pool): the replaced
 			// transaction is fully sender-paid, so its whole cost belongs to the sender.
 			isReplacement = true
-			prevGasCost = prev // prev == old.Cost(); oldGasPayer == from
+			prevGasCost = prev
 		}
 
 		// need computes an account's total pooled obligation (value owed as a

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -277,21 +277,17 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		}
 	}
 
-	// Cumulative overdraft protection (DoS hardening).
+	// Cumulative overdraft protection.
 	//
-	// A transaction can clear the per-tx balance checks above yet still be
-	// uncoverable once combined with the account's other pooled obligations. Left
-	// unchecked, an attacker can flood the pool with individually-valid but
-	// collectively-unfundable transactions (sequential value overdrafts from one
-	// sender, or many senders piling gas onto a single fee payer) that mostly
-	// revert on execution and pollute the mempool.
+	// A transaction can pass the per-tx balance checks above but still become
+	// unaffordable when combined with the account's other pending obligations. This
+	// allows individually valid but collectively unfundable transactions to occupy
+	// txpool resources.
 	//
-	// Fee delegation (tx type 0x16) splits an obligation across two accounts: the
-	// sender owes the value, the fee payer owes the gas (FeeCost). The
-	// ExistingExpenditure callback therefore reports each account's *total*
-	// obligation across every role it plays (value as sender, gas as its own gas
-	// payer, and gas as a fee payer for others), so the checks below remain correct
-	// for both normal and fee-delegated transactions.
+	// Fee delegation splits the obligation across two accounts: the sender owes
+	// value and the fee payer owes gas. ExistingExpenditure reports each account's
+	// cumulative pending obligation across all roles, so the checks below work for
+	// both ordinary and fee-delegated transactions.
 	if opts.ExistingExpenditure != nil {
 		// Determine who is responsible for the gas fee of the incoming transaction.
 		gasPayer := from

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -209,12 +209,22 @@ type ValidationOptionsWithState struct {
 	UsedAndLeftSlots func(addr common.Address) (int, int)
 
 	// ExistingExpenditure is a mandatory callback to retrieve the cumulative
-	// cost of the already pooled transactions to check for overdrafts.
+	// obligation of the already pooled transactions to check for overdrafts. The
+	// obligation includes sender value, self-paid gas, and delegated gas charged to
+	// the fee payer.
 	ExistingExpenditure func(addr common.Address) *big.Int
 
 	// ExistingCost is a mandatory callback to retrieve an already pooled
 	// transaction's cost with the given nonce to check for overdrafts.
 	ExistingCost func(addr common.Address, nonce uint64) *big.Int
+
+	// ExistingTx is an optional callback to retrieve the already pooled
+	// transaction (if any) with the given sender and nonce, i.e. the transaction
+	// that an incoming one would replace. It lets the cumulative overdraft check
+	// split the replaced transaction's value and gas across the right accounts,
+	// which is required for fee-delegated transactions. When nil, the check falls
+	// back to ExistingCost and assumes the replaced transaction was sender-paid.
+	ExistingTx func(addr common.Address, nonce uint64) *types.Transaction
 }
 
 // ValidateTransactionWithState is a helper method to check whether a transaction
@@ -267,34 +277,112 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		}
 	}
 
-	// go-wbft skips cumulative balance validation for fee delegation tx compatibility.
-	// Fee delegation transactions split costs between sender (value only) and feePayer (gas fees),
-	// but ExistingExpenditure callback sums total tx.Cost() which is incompatible with this model.
-	// Enabling this validation would incorrectly reject transactions when fee delegation txs exist
-	// in the pending pool, as it would compare sender's balance against the full cost (value + gas).
-	// Transaction replacement is still supported via legacypool's price bump mechanism.
-	/*
-		// Ensure the transactor has enough funds to cover for replacements or nonce
-		// expansions without overdrafts
-		spent := opts.ExistingExpenditure(from)
-		if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
-			bump := new(big.Int).Sub(cost, prev)
-			need := new(big.Int).Add(spent, bump)
-			if balance.Cmp(need) < 0 {
-				return fmt.Errorf("%w: balance %v, queued cost %v, tx bumped %v, overshot %v", core.ErrInsufficientFunds, balance, spent, bump, new(big.Int).Sub(need, balance))
+	// Cumulative overdraft protection (DoS hardening).
+	//
+	// A transaction can clear the per-tx balance checks above yet still be
+	// uncoverable once combined with the account's other pooled obligations. Left
+	// unchecked, an attacker can flood the pool with individually-valid but
+	// collectively-unfundable transactions (sequential value overdrafts from one
+	// sender, or many senders piling gas onto a single fee payer) that mostly
+	// revert on execution and pollute the mempool.
+	//
+	// Fee delegation (tx type 0x16) splits an obligation across two accounts: the
+	// sender owes the value, the fee payer owes the gas (FeeCost). The
+	// ExistingExpenditure callback therefore reports each account's *total*
+	// obligation across every role it plays (value as sender, gas as its own gas
+	// payer, and gas as a fee payer for others), so the checks below remain correct
+	// for both normal and fee-delegated transactions.
+	if opts.ExistingExpenditure != nil {
+		// Determine who is responsible for the gas fee of the incoming transaction.
+		gasPayer := from
+		if tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+			gasPayer = *tx.FeePayer()
+		}
+		txValue := tx.Value()
+		txGasCost := tx.FeeCost() // tx.Cost() - tx.Value()
+
+		// If a transaction with the same sender and nonce is already pooled, the
+		// incoming one replaces it, so its contribution must be discounted from
+		// whichever account currently carries it (value -> sender, gas -> its own
+		// gas payer, which may differ from the new transaction's gas payer).
+		var (
+			isReplacement bool
+			prevGasPayer  = from
+			prevValue     = new(big.Int)
+			prevGasCost   = new(big.Int)
+		)
+		if opts.ExistingTx != nil {
+			if prev := opts.ExistingTx(from, tx.Nonce()); prev != nil {
+				isReplacement = true
+				prevValue = prev.Value()
+				prevGasCost = prev.FeeCost()
+				if prev.Type() == types.FeeDelegateDynamicFeeTxType && prev.FeePayer() != nil {
+					prevGasPayer = *prev.FeePayer()
+				}
+			}
+		} else if prev := opts.ExistingCost(from, tx.Nonce()); prev != nil {
+			// Pools without fee-delegation support (e.g. the blob pool): the replaced
+			// transaction is fully sender-paid, so its whole cost belongs to the sender.
+			isReplacement = true
+			prevGasCost = prev // prev == old.Cost(); oldGasPayer == from
+		}
+
+		// need computes an account's total pooled obligation (value owed as a
+		// sender plus gas owed as a gas payer), augmented by the incoming
+		// transaction's deltas and discounted by any transaction being replaced.
+		need := func(addr common.Address, curValue, curGasCost *big.Int) (*big.Int, error) {
+			n := new(big.Int).Set(opts.ExistingExpenditure(addr))
+			if isReplacement {
+				if addr == from {
+					n.Sub(n, prevValue)
+				}
+				if addr == prevGasPayer {
+					n.Sub(n, prevGasCost)
+				}
+				if n.Sign() < 0 {
+					return nil, fmt.Errorf("%w: addr %v, underflow %v",
+						core.ErrTxPoolAccountingUnderflow, addr, new(big.Int).Neg(n))
+				}
+			}
+			// Incoming tx contribution.
+			if addr == from {
+				n.Add(n, curValue)
+			}
+			if addr == gasPayer {
+				n.Add(n, curGasCost)
+			}
+			return n, nil
+		}
+		if from == gasPayer {
+			// Self-paid: value and gas are drawn from the same balance and must be
+			// checked combined, otherwise an account could overdraft by splitting
+			// its obligations across two independent checks.
+			combinedNeed, err := need(from, txValue, txGasCost)
+			if err != nil {
+				return err
+			}
+			if balance.Cmp(combinedNeed) < 0 {
+				return fmt.Errorf("%w: balance %v, needed %v, overshot %v", core.ErrInsufficientFunds, balance, combinedNeed, new(big.Int).Sub(combinedNeed, balance))
 			}
 		} else {
-			need := new(big.Int).Add(spent, cost)
-			if balance.Cmp(need) < 0 {
-				return fmt.Errorf("%w: balance %v, queued cost %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, balance, spent, cost, new(big.Int).Sub(need, balance))
+			// Fee delegation: the sender covers its value obligations, the fee
+			// payer covers its gas obligations, each against its own balance.
+			senderNeed, err := need(from, txValue, txGasCost)
+			if err != nil {
+				return err
 			}
-			// Transaction takes a new nonce value out of the pool. Ensure it doesn't
-			// overflow the number of permitted transactions from a single account
-			// (i.e. max cancellable via out-of-bound transaction).
-			if used, left := opts.UsedAndLeftSlots(from); left <= 0 {
-				return fmt.Errorf("%w: pooled %d txs", ErrAccountLimitExceeded, used)
+			if balance.Cmp(senderNeed) < 0 {
+				return fmt.Errorf("%w: sender balance %v, needed %v, overshot %v", ErrSenderInsufficientFunds, balance, senderNeed, new(big.Int).Sub(senderNeed, balance))
+			}
+			feePayerBalance := opts.State.GetBalance(gasPayer).ToBig()
+			feePayerNeed, err := need(gasPayer, txValue, txGasCost)
+			if err != nil {
+				return err
+			}
+			if feePayerBalance.Cmp(feePayerNeed) < 0 {
+				return fmt.Errorf("%w: fee payer balance %v, needed %v, overshot %v", ErrFeePayerInsufficientFunds, feePayerBalance, feePayerNeed, new(big.Int).Sub(feePayerNeed, feePayerBalance))
 			}
 		}
-	*/
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fee-delegated transactions (type `0x16`) split their financial obligations:

- the sender pays `tx.Value()`
- the fee payer pays `tx.FeeCost()`

The upstream cumulative overdraft check introduced by ethereum/go-ethereum#27429 assumed that the sender pays the entire transactioncost. Because that assumption caused false rejections for fee-delegated transactions, the check had been disabled globally.

Disabling it allowed individually affordable but collectively unfundable transactions to occupy txpool capacity:

1. A sender could submit sequential transactions whose cumulative cost exceeded its balance.
2. Multiple senders could charge gas to the same fee payer until the aggregate obligation exceeded the fee payer's balance.
3. Queued transactions could bypass the pending-only accounting and become collectively unaffordable when promoted together.

This change restores cumulative overdraft protection while accounting for sender and fee-payer obligations separately.

## Changes

### Cumulative accounting

- Keep `list.totalcost` for sender-side pending obligations:
  - normal transaction: `tx.Cost()`
  - fee-delegated transaction: `tx.Value()`
- Add pool-wide `pendingGas`, indexed by fee payer, to aggregate delegated gas obligations across sender lists.
- Make pending lists update `pendingGas` through paired add/remove callbacks. Queued transactions remain outside pending expenditure accounting.
- Ignore zero gas obligations symmetrically and detect accounting underflows as internal invariant failures.

### Stateful validation

- Restore cumulative overdraft validation for normal transactions.
- Check fee-delegated sender value and fee-payer gas against their respective balances.
- Add `ExistingTx` so replacement validation can subtract the previous transaction's value and gas from the correct accounts, including fee-payer changes.
- Reuse the same state validation options for submission and queued promotion.

### Promotion and demotion

- Revalidate each ready fee-delegated transaction before promoting it from queue to pending.
- Account for transactions promoted earlier in the same pass when checking a shared fee payer.
- On the first promotion failure, drop the rejected transaction and its dependent nonce tail.
- Disable the list filter short circuit while fee-delegated transactions are present, ensuring a transaction is removed from pending if its fee payer later becomes unable to cover the gas obligation.

### Tests

- Restore blob-pool cumulative insufficient-funds expectations.
- Add coverage for:
  - cumulative delegated gas across multiple senders
  - cumulative validation during queued promotion
  - rejected nonce-tail removal
  - zero-value `pendingGas` accounting
  - fee-delegated list-counter consistency
  - filter behavior after fee-payer insolvency

## Test

- [x] `go test ./core/txpool/legacypool ./core/txpool/blobpool`
- [x] `go test -race ./core/txpool/legacypool`
- [x] `git diff --check origin/dev...HEAD`

## Related PR

This PR supersedes #192. See #192 for the original discussion and review history.