### PR TITLE
chore: update .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,12 @@ profile.cov
 logs/
 
 tests/spec-tests/
+
+# Sensitive files (do not commit)
+.env
+.env.*
+*.pem
+*.key
+.aws/
+.azure/
+.ssh/


### PR DESCRIPTION
## Summary
- Add common sensitive files and credential paths to `.gitignore`
- Prevent accidental commit of local secrets and private keys

## Changes
- Ignore environment files (`.env*`)
- Ignore private key files (`*.pem`, `*.key`)
- Ignore cloud credentials (`.aws`, `.azure`)
- Ignore SSH configuration files (`.ssh`)