### PR TITLE
ci: replace echo SSH key with webfactory/ssh-agent

### DIFF
--- a/.github/workflows/dev-test-work.yaml
+++ b/.github/workflows/dev-test-work.yaml
@@ -40,11 +40,9 @@ jobs:
           ls -l ./output/
 
       - name: Configure SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Clone Target Repository
         run: |


### PR DESCRIPTION
Replace writing SSH private key to disk via echo with webfactory/ssh-agent action, which loads the key into memory only and never writes it to the filesystem.